### PR TITLE
Adds specular lighting to objects with global illumination.

### DIFF
--- a/com.unity.render-pipelines.core/ShaderLibrary/Common.hlsl
+++ b/com.unity.render-pipelines.core/ShaderLibrary/Common.hlsl
@@ -600,13 +600,6 @@ real Pow4(real x)
 
 TEMPLATE_3_FLT(RangeRemap, min, max, t, return saturate((t - min) / (max - min)))
 
-// Includes clamping.
-real RangeRemapTo(real value, real srcMin, real srcMax, real dstMin, real dstMax) {
-    real value01 = RangeRemap(srcMin, srcMax, value); // clamped
-    real result = dstMin + (dstMax - dstMin) * value01;
-    return result;
-}
-
 // ----------------------------------------------------------------------------
 // Texture utilities
 // ----------------------------------------------------------------------------

--- a/com.unity.render-pipelines.core/ShaderLibrary/Common.hlsl
+++ b/com.unity.render-pipelines.core/ShaderLibrary/Common.hlsl
@@ -600,6 +600,13 @@ real Pow4(real x)
 
 TEMPLATE_3_FLT(RangeRemap, min, max, t, return saturate((t - min) / (max - min)))
 
+// Includes clamping.
+real RangeRemapTo(real value, real srcMin, real srcMax, real dstMin, real dstMax) {
+    real value01 = RangeRemap(srcMin, srcMax, value); // clamped
+    real result = dstMin + (dstMax - dstMin) * value01;
+    return result;
+}
+
 // ----------------------------------------------------------------------------
 // Texture utilities
 // ----------------------------------------------------------------------------

--- a/com.unity.render-pipelines.core/ShaderLibrary/Debug.hlsl
+++ b/com.unity.render-pipelines.core/ShaderLibrary/Debug.hlsl
@@ -277,19 +277,97 @@ real3 GetColorCodeFunction(real value, real4 threshold)
 }
 
 // Maps a value within the range to the range of colors in a heatmap.
-half4 HeatMapColor(half value, half minValue, half maxValue)
+// 3 color bands: Red, Black, Green
+half4 HeatMapColorRedBlackGreen(half value, half minValue, half maxValue)
 {
-    #define HEATMAP_COLORS_COUNT 2
+    #define HEATMAP_COLORS_COUNT 3
     half4 colors[HEATMAP_COLORS_COUNT] =
     {
+        // min value of the range
         //half4(0.32, 0.00, 0.32, 1.00),
         //half4(0.00, 0.00, 1.00, 1.00),
         //half4(0.00, 1.00, 0.00, 1.00),
         //half4(1.00, 1.00, 0.00, 1.00),
         //half4(1.00, 0.60, 0.00, 1.00),
         //half4(1.00, 0.00, 0.00, 1.00),
-        half4(0, 1, 0, 1),
-        half4(1, 0, 0, 1)
+        half4(1, 0, 0, 1),
+        half4(0, 0, 0, 1),
+        half4(0, 1, 0, 1)
+        // max value of the range
+    };
+    half ratio=(HEATMAP_COLORS_COUNT-1.0)*saturate((value-minValue)/(maxValue-minValue));
+    half indexMin=floor(ratio);
+    half indexMax=min(indexMin+1,HEATMAP_COLORS_COUNT-1);
+
+    return lerp(colors[indexMin], colors[indexMax], ratio-indexMin);
+}
+
+// Maps a value within the range to the range of colors in a heatmap.
+// 3 color bands: Red, Black, White
+half4 HeatMapColorRedBlackWhite(half value, half minValue, half maxValue)
+{
+    #define HEATMAP_COLORS_COUNT 3
+    half4 colors[HEATMAP_COLORS_COUNT] =
+    {
+        // min value of the range
+        //half4(0.32, 0.00, 0.32, 1.00),
+        //half4(0.00, 0.00, 1.00, 1.00),
+        //half4(0.00, 1.00, 0.00, 1.00),
+        //half4(1.00, 1.00, 0.00, 1.00),
+        //half4(1.00, 0.60, 0.00, 1.00),
+        //half4(1.00, 0.00, 0.00, 1.00),
+        half4(1, 0, 0, 1),
+        half4(0, 0, 0, 1),
+        half4(1, 1, 1, 1)
+        // max value of the range
+    };
+    half ratio=(HEATMAP_COLORS_COUNT-1.0)*saturate((value-minValue)/(maxValue-minValue));
+    half indexMin=floor(ratio);
+    half indexMax=min(indexMin+1,HEATMAP_COLORS_COUNT-1);
+
+    return lerp(colors[indexMin], colors[indexMax], ratio-indexMin);
+}
+
+// Maps a value within the range to the range of colors in a heatmap.
+// 2 color bands: Red, Black, White
+half4 HeatMapColorBlackWhite(half value, half minValue, half maxValue)
+{
+    #define HEATMAP_COLORS_COUNT 2
+    half4 colors[HEATMAP_COLORS_COUNT] =
+    {
+        // min value of the range
+        //half4(0.32, 0.00, 0.32, 1.00),
+        //half4(0.00, 0.00, 1.00, 1.00),
+        //half4(0.00, 1.00, 0.00, 1.00),
+        //half4(1.00, 1.00, 0.00, 1.00),
+        //half4(1.00, 0.60, 0.00, 1.00),
+        //half4(1.00, 0.00, 0.00, 1.00),
+        half4(0, 0, 0, 1),
+        half4(1, 1, 1, 1)
+        // max value of the range
+    };
+    half ratio=(HEATMAP_COLORS_COUNT-1.0)*saturate((value-minValue)/(maxValue-minValue));
+    half indexMin=floor(ratio);
+    half indexMax=min(indexMin+1,HEATMAP_COLORS_COUNT-1);
+
+    return lerp(colors[indexMin], colors[indexMax], ratio-indexMin);
+}
+
+// Maps a value within the range to the range of colors in a heatmap.
+// 6 color bands
+half4 HeatMapColorMulticolor(half value, half minValue, half maxValue)
+{
+    #define HEATMAP_COLORS_COUNT 6
+    half4 colors[HEATMAP_COLORS_COUNT] =
+    {
+        // min value of the range
+        half4(0.32, 0.00, 0.32, 1.00),
+        half4(0.00, 0.00, 1.00, 1.00),
+        half4(0.00, 1.00, 0.00, 1.00),
+        half4(1.00, 1.00, 0.00, 1.00),
+        half4(1.00, 0.60, 0.00, 1.00),
+        half4(1.00, 0.00, 0.00, 1.00),
+        // max value of the range
     };
     half ratio=(HEATMAP_COLORS_COUNT-1.0)*saturate((value-minValue)/(maxValue-minValue));
     half indexMin=floor(ratio);

--- a/com.unity.render-pipelines.core/ShaderLibrary/Debug.hlsl
+++ b/com.unity.render-pipelines.core/ShaderLibrary/Debug.hlsl
@@ -276,4 +276,26 @@ real3 GetColorCodeFunction(real value, real4 threshold)
     return outColor;
 }
 
+// Maps a value within the range to the range of colors in a heatmap.
+half4 HeatMapColor(half value, half minValue, half maxValue)
+{
+    #define HEATMAP_COLORS_COUNT 2
+    half4 colors[HEATMAP_COLORS_COUNT] =
+    {
+        //half4(0.32, 0.00, 0.32, 1.00),
+        //half4(0.00, 0.00, 1.00, 1.00),
+        //half4(0.00, 1.00, 0.00, 1.00),
+        //half4(1.00, 1.00, 0.00, 1.00),
+        //half4(1.00, 0.60, 0.00, 1.00),
+        //half4(1.00, 0.00, 0.00, 1.00),
+        half4(0, 1, 0, 1),
+        half4(1, 0, 0, 1)
+    };
+    half ratio=(HEATMAP_COLORS_COUNT-1.0)*saturate((value-minValue)/(maxValue-minValue));
+    half indexMin=floor(ratio);
+    half indexMax=min(indexMin+1,HEATMAP_COLORS_COUNT-1);
+
+    return lerp(colors[indexMin], colors[indexMax], ratio-indexMin);
+}
+
 #endif // UNITY_DEBUG_INCLUDED

--- a/com.unity.render-pipelines.universal/ShaderLibrary/Input.hlsl
+++ b/com.unity.render-pipelines.universal/ShaderLibrary/Input.hlsl
@@ -33,6 +33,7 @@ struct InputData
     half    fogCoord;
     half3   vertexLighting;
     half3   bakedGI;
+    half3   bakedGI_directionWS;
 };
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/com.unity.render-pipelines.universal/ShaderLibrary/Input.hlsl
+++ b/com.unity.render-pipelines.universal/ShaderLibrary/Input.hlsl
@@ -33,7 +33,7 @@ struct InputData
     half    fogCoord;
     half3   vertexLighting;
     half3   bakedGI;
-    half3   bakedGI_directionWS;
+    half4   bakedGI_directionWS;
 };
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/com.unity.render-pipelines.universal/ShaderLibrary/Input.hlsl
+++ b/com.unity.render-pipelines.universal/ShaderLibrary/Input.hlsl
@@ -33,7 +33,7 @@ struct InputData
     half    fogCoord;
     half3   vertexLighting;
     half3   bakedGI;
-    half4   bakedGI_directionWS;
+    half3   bakedGI_directionWS; // XYZ: Light direction, length is 'directionality'
 };
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/com.unity.render-pipelines.universal/ShaderLibrary/Lighting.hlsl
+++ b/com.unity.render-pipelines.universal/ShaderLibrary/Lighting.hlsl
@@ -588,7 +588,7 @@ half4 UniversalFragmentPBR(InputData inputData, half3 albedo, half metallic, hal
     // smoothness to linear smoothness. Worth optimizing if we become ALU bound. Just make sure to do a before/after.
     // This smoothness falloff has been carefully tested to look good.
     half linearSmoothness = 1 - PerceptualSmoothnessToRoughness(smoothness);
-    half directionality = length(inputData.bakedGI_directionWS.xyz);
+    half directionality = length(inputData.bakedGI_directionWS);
     half adjustedSmoothness = linearSmoothness * pow(RangeRemap(0.0, .9, directionality), 2);
     half perceptualAdjustedSmoothness = 1 - RoughnessToPerceptualRoughness(1 - adjustedSmoothness);
 
@@ -598,7 +598,7 @@ half4 UniversalFragmentPBR(InputData inputData, half3 albedo, half metallic, hal
     Light mainLight = GetMainLight(inputData.shadowCoord);
     MixRealtimeAndBakedGI(mainLight, inputData.normalWS, inputData.bakedGI, half4(0, 0, 0, 0));
 
-    half3 giDirectionWS = SafeNormalize(inputData.bakedGI_directionWS.xyz);
+    half3 giDirectionWS = SafeNormalize(inputData.bakedGI_directionWS);
     half3 color = GlobalIllumination(brdfData, inputData.bakedGI, giDirectionWS, occlusion, inputData.normalWS, inputData.viewDirectionWS);
     color += LightingPhysicallyBased(brdfData, mainLight, inputData.normalWS, inputData.viewDirectionWS);
 

--- a/com.unity.render-pipelines.universal/ShaderLibrary/Lighting.hlsl
+++ b/com.unity.render-pipelines.universal/ShaderLibrary/Lighting.hlsl
@@ -570,13 +570,13 @@ half4 UniversalFragmentPBR(InputData inputData, half3 albedo, half metallic, hal
     // This is recommended by: https://media.contentapi.ea.com/content/dam/eacom/frostbite/files/gdc2018-precomputedgiobalilluminationinfrostbite.pdf
     // Although, here we do not apply the sqrt to the falloff. Instead we square it, which seems to produce a closer image to the blender groundtruth.
     // The range remap makes sure that surfaces in perfectly direct light (directionality > .9) remain their true specular (directionality rarely reaches a perfect 1).
+    // See this Github discussion for more information: https://github.com/AStrangerGravity/Graphics/pull/2#discussion_r459731172
 
-    // TODO(john): We could collapse this math down a lot, if we knew the proper transformations from perceptual
-    // smoothness to linear smoothness. Worth optimizing if we become ALU bound. Just make sure to do a before/after.
-    // This smoothness falloff has been carefully tested to look good.
-    half linearSmoothness = 1 - PerceptualSmoothnessToRoughness(smoothness);
-    half directionality = length(inputData.bakedGI_directionWS);
-    half adjustedSmoothness = linearSmoothness * pow(RangeRemap(0.0, .9, directionality), 2);
+    // Worth optimizing more if we become ALU bound. Just make sure to do a before/after.
+    // This smoothness falloff has been carefully tested to look good compared to the Blender render.
+    half physicalSmoothness = 1 - PerceptualSmoothnessToRoughness(smoothness);
+    half directionality_squared = dot(inputData.bakedGI_directionWS, inputData.bakedGI_directionWS); // The directionality is encoded as the length of the GI direction vector.
+    half adjustedSmoothness = physicalSmoothness * RangeRemap(0.0, .9 * .9, directionality_squared);
     half perceptualAdjustedSmoothness = 1 - RoughnessToPerceptualRoughness(1 - adjustedSmoothness);
 
     BRDFData brdfData;

--- a/com.unity.render-pipelines.universal/ShaderLibrary/Lighting.hlsl
+++ b/com.unity.render-pipelines.universal/ShaderLibrary/Lighting.hlsl
@@ -583,7 +583,8 @@ half4 UniversalFragmentPBR(InputData inputData, half3 albedo, half metallic, hal
     Light mainLight = GetMainLight(inputData.shadowCoord);
     MixRealtimeAndBakedGI(mainLight, inputData.normalWS, inputData.bakedGI, half4(0, 0, 0, 0));
 
-    half3 color = GlobalIllumination(brdfData, inputData.bakedGI, inputData.bakedGI_directionWS, occlusion, inputData.normalWS, inputData.viewDirectionWS);
+
+    half3 color = GlobalIllumination(brdfData, inputData.bakedGI, inputData.bakedGI_directionWS.xyz, occlusion, inputData.normalWS, inputData.viewDirectionWS);
     color += LightingPhysicallyBased(brdfData, mainLight, inputData.normalWS, inputData.viewDirectionWS);
 
 #ifdef _ADDITIONAL_LIGHTS

--- a/com.unity.render-pipelines.universal/ShaderLibrary/Lighting.hlsl
+++ b/com.unity.render-pipelines.universal/ShaderLibrary/Lighting.hlsl
@@ -205,7 +205,7 @@ int GetPerObjectLightIndex(uint index)
 #elif !defined(SHADER_API_GLES)
     // since index is uint shader compiler will implement
     // div & mod as bitfield ops (shift and mask).
-    
+
     // TODO: Can we index a float4? Currently compiler is
     // replacing unity_LightIndicesX[i] with a dp4 with identity matrix.
     // u_xlat16_40 = dot(unity_LightIndices[int(u_xlatu13)], ImmCB_0_0_0[u_xlati1]);
@@ -495,19 +495,6 @@ half3 SubtractDirectMainLightFromLightmap(Light mainLight, half3 normalWS, half3
     // 3) Pick darkest color
     return min(bakedGI, realtimeShadow);
 }
-
-// (ASG) The original implementation of GI.
-/*half3 GlobalIllumination(BRDFData brdfData, half3 bakedGI, half occlusion, half3 normalWS, half3 viewDirectionWS)
-{
-    half3 reflectVector = reflect(-viewDirectionWS, normalWS);
-    half fresnelTerm = Pow4(1.0 - saturate(dot(normalWS, viewDirectionWS)));
-
-    half3 indirectDiffuse = bakedGI * occlusion;
-
-    half3 indirectSpecular = GlossyEnvironmentReflection(reflectVector, brdfData.perceptualRoughness, occlusion);
-
-    return EnvironmentBRDF(brdfData, indirectDiffuse, indirectSpecular, fresnelTerm);
-}*/
 
 // (ASG) Calculates the GI by treating GI as simply another light source we pass into the DirectBRDF.
 // This gives us nice specular contribution from the baked lights! Very helpful in VR for making an object appear grounded.

--- a/com.unity.render-pipelines.universal/ShaderLibrary/Lighting.hlsl
+++ b/com.unity.render-pipelines.universal/ShaderLibrary/Lighting.hlsl
@@ -204,7 +204,7 @@ int GetPerObjectLightIndex(uint index)
 #elif !defined(SHADER_API_GLES)
     // since index is uint shader compiler will implement
     // div & mod as bitfield ops (shift and mask).
-
+    
     // TODO: Can we index a float4? Currently compiler is
     // replacing unity_LightIndicesX[i] with a dp4 with identity matrix.
     // u_xlat16_40 = dot(unity_LightIndices[int(u_xlatu13)], ImmCB_0_0_0[u_xlati1]);

--- a/com.unity.render-pipelines.universal/ShaderLibrary/Lighting.hlsl
+++ b/com.unity.render-pipelines.universal/ShaderLibrary/Lighting.hlsl
@@ -4,7 +4,6 @@
 #include "Packages/com.unity.render-pipelines.core/ShaderLibrary/Common.hlsl"
 #include "Packages/com.unity.render-pipelines.core/ShaderLibrary/EntityLighting.hlsl"
 #include "Packages/com.unity.render-pipelines.core/ShaderLibrary/ImageBasedLighting.hlsl"
-#include "Packages/com.unity.render-pipelines.core/ShaderLibrary/Debug.hlsl"
 #include "Packages/com.unity.render-pipelines.universal/ShaderLibrary/Core.hlsl"
 #include "Packages/com.unity.render-pipelines.universal/ShaderLibrary/Shadows.hlsl"
 

--- a/com.unity.render-pipelines.universal/Shaders/LitForwardPass.hlsl
+++ b/com.unity.render-pipelines.universal/Shaders/LitForwardPass.hlsl
@@ -73,7 +73,22 @@ void InitializeInputData(Varyings input, half3 normalTS, out InputData inputData
 
     inputData.fogCoord = input.fogFactorAndVertexLight.x;
     inputData.vertexLighting = input.fogFactorAndVertexLight.yzw;
+
     inputData.bakedGI = SAMPLE_GI(input.lightmapUV, input.vertexSH, inputData.normalWS);
+
+    // Get the direction of the lightmap lighting (scale is equal to the 'directionality')
+    #ifdef LIGHTMAP_ON
+
+    half2 uv = input.lightmapUV;
+
+    real4 direction = SAMPLE_TEXTURE2D(unity_LightmapInd, samplerunity_Lightmap, uv);
+    inputData.bakedGI_directionWS = SafeNormalize(direction.xyz);
+
+    #else // LIGHTMAP_ON
+
+    inputData.bakedGI_directionWS = half3(0,0,0);
+
+    #endif
 }
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/com.unity.render-pipelines.universal/Shaders/LitForwardPass.hlsl
+++ b/com.unity.render-pipelines.universal/Shaders/LitForwardPass.hlsl
@@ -83,11 +83,11 @@ void InitializeInputData(Varyings input, half3 normalTS, out InputData inputData
 
     real4 direction_raw = SAMPLE_TEXTURE2D(unity_LightmapInd, samplerunity_Lightmap, uv);
     half3 direction = (direction_raw.xyz - 0.5) * 2; // convert from [0,1] to [-1,1]
-    inputData.bakedGI_directionWS = half4(direction.x, direction.y, direction.z, direction_raw.w);
+    inputData.bakedGI_directionWS = half3(direction.x, direction.y, direction.z);
 
     #else // LIGHTMAP_ON
 
-    inputData.bakedGI_directionWS = half4(0,0,0,0);
+    inputData.bakedGI_directionWS = half3(0,0,0);
 
     #endif
 }

--- a/com.unity.render-pipelines.universal/Shaders/LitForwardPass.hlsl
+++ b/com.unity.render-pipelines.universal/Shaders/LitForwardPass.hlsl
@@ -86,7 +86,7 @@ void InitializeInputData(Varyings input, half3 normalTS, out InputData inputData
     // in, instead.
     real4 direction_raw = SAMPLE_TEXTURE2D(unity_LightmapInd, samplerunity_Lightmap, uv);
     half3 direction = (direction_raw.xyz - 0.5) * 2; // convert from [0,1] to [-1,1]
-    inputData.bakedGI_directionWS = half3(direction.x, direction.y, direction.z);
+    inputData.bakedGI_directionWS = direction;
 
     #else // LIGHTMAP_ON
 

--- a/com.unity.render-pipelines.universal/Shaders/LitForwardPass.hlsl
+++ b/com.unity.render-pipelines.universal/Shaders/LitForwardPass.hlsl
@@ -81,12 +81,13 @@ void InitializeInputData(Varyings input, half3 normalTS, out InputData inputData
 
     half2 uv = input.lightmapUV;
 
-    real4 direction = SAMPLE_TEXTURE2D(unity_LightmapInd, samplerunity_Lightmap, uv);
-    inputData.bakedGI_directionWS = SafeNormalize(direction.xyz);
+    real4 direction_raw = SAMPLE_TEXTURE2D(unity_LightmapInd, samplerunity_Lightmap, uv);
+    half3 direction = SafeNormalize(direction_raw.xyz - 0.5);
+    inputData.bakedGI_directionWS = half4(direction.x, direction.y, direction.z, direction_raw.w);
 
     #else // LIGHTMAP_ON
 
-    inputData.bakedGI_directionWS = half3(0,0,0);
+    inputData.bakedGI_directionWS = half4(0,0,0,0);
 
     #endif
 }

--- a/com.unity.render-pipelines.universal/Shaders/LitForwardPass.hlsl
+++ b/com.unity.render-pipelines.universal/Shaders/LitForwardPass.hlsl
@@ -81,6 +81,9 @@ void InitializeInputData(Varyings input, half3 normalTS, out InputData inputData
 
     half2 uv = input.lightmapUV;
 
+    // TODO(fixforship): This adds an *additional* unnecessary texture fetch to the shader. We're already sampling
+    // the directional lightmap in the SAMPLE_GI function, so we should sample it first, and feed it
+    // in, instead.
     real4 direction_raw = SAMPLE_TEXTURE2D(unity_LightmapInd, samplerunity_Lightmap, uv);
     half3 direction = (direction_raw.xyz - 0.5) * 2; // convert from [0,1] to [-1,1]
     inputData.bakedGI_directionWS = half3(direction.x, direction.y, direction.z);

--- a/com.unity.render-pipelines.universal/Shaders/LitForwardPass.hlsl
+++ b/com.unity.render-pipelines.universal/Shaders/LitForwardPass.hlsl
@@ -82,7 +82,7 @@ void InitializeInputData(Varyings input, half3 normalTS, out InputData inputData
     half2 uv = input.lightmapUV;
 
     real4 direction_raw = SAMPLE_TEXTURE2D(unity_LightmapInd, samplerunity_Lightmap, uv);
-    half3 direction = SafeNormalize(direction_raw.xyz - 0.5);
+    half3 direction = (direction_raw.xyz - 0.5) * 2; // convert from [0,1] to [-1,1]
     inputData.bakedGI_directionWS = half4(direction.x, direction.y, direction.z, direction_raw.w);
 
     #else // LIGHTMAP_ON

--- a/com.unity.render-pipelines.universal/Shaders/Nature/SpeedTree7CommonPasses.hlsl
+++ b/com.unity.render-pipelines.universal/Shaders/Nature/SpeedTree7CommonPasses.hlsl
@@ -86,6 +86,7 @@ void InitializeInputData(SpeedTreeVertexOutput input, half3 normalTS, out InputD
     inputData.fogCoord = input.fogFactorAndVertexLight.x;
     inputData.vertexLighting = input.fogFactorAndVertexLight.yzw;
     inputData.bakedGI = half3(0, 0, 0); // No GI currently.
+    inputData.bakedGI_directionWS = half3(0,0,0);
 }
 
 half4 SpeedTree7Frag(SpeedTreeVertexOutput input) : SV_Target

--- a/com.unity.render-pipelines.universal/Shaders/Nature/SpeedTree7CommonPasses.hlsl
+++ b/com.unity.render-pipelines.universal/Shaders/Nature/SpeedTree7CommonPasses.hlsl
@@ -86,7 +86,7 @@ void InitializeInputData(SpeedTreeVertexOutput input, half3 normalTS, out InputD
     inputData.fogCoord = input.fogFactorAndVertexLight.x;
     inputData.vertexLighting = input.fogFactorAndVertexLight.yzw;
     inputData.bakedGI = half3(0, 0, 0); // No GI currently.
-    inputData.bakedGI_directionWS = half3(0,0,0);
+    inputData.bakedGI_directionWS = half4(0,0,0,0);
 }
 
 half4 SpeedTree7Frag(SpeedTreeVertexOutput input) : SV_Target

--- a/com.unity.render-pipelines.universal/Shaders/Nature/SpeedTree7CommonPasses.hlsl
+++ b/com.unity.render-pipelines.universal/Shaders/Nature/SpeedTree7CommonPasses.hlsl
@@ -86,7 +86,7 @@ void InitializeInputData(SpeedTreeVertexOutput input, half3 normalTS, out InputD
     inputData.fogCoord = input.fogFactorAndVertexLight.x;
     inputData.vertexLighting = input.fogFactorAndVertexLight.yzw;
     inputData.bakedGI = half3(0, 0, 0); // No GI currently.
-    inputData.bakedGI_directionWS = half4(0,0,0,0);
+    inputData.bakedGI_directionWS = half3(0,0,0);
 }
 
 half4 SpeedTree7Frag(SpeedTreeVertexOutput input) : SV_Target

--- a/com.unity.render-pipelines.universal/Shaders/Nature/SpeedTree8Passes.hlsl
+++ b/com.unity.render-pipelines.universal/Shaders/Nature/SpeedTree8Passes.hlsl
@@ -291,6 +291,7 @@ void InitializeInputData(SpeedTreeFragmentInput input, half3 normalTS, out Input
     inputData.fogCoord = input.interpolated.fogFactorAndVertexLight.x;
     inputData.vertexLighting = input.interpolated.fogFactorAndVertexLight.yzw;
     inputData.bakedGI = half3(0, 0, 0); // No GI currently.
+    inputData.bakedGI_directionWS = half3(0,0,0);
 }
 
 half4 SpeedTree8Frag(SpeedTreeFragmentInput input) : SV_Target

--- a/com.unity.render-pipelines.universal/Shaders/Nature/SpeedTree8Passes.hlsl
+++ b/com.unity.render-pipelines.universal/Shaders/Nature/SpeedTree8Passes.hlsl
@@ -291,7 +291,7 @@ void InitializeInputData(SpeedTreeFragmentInput input, half3 normalTS, out Input
     inputData.fogCoord = input.interpolated.fogFactorAndVertexLight.x;
     inputData.vertexLighting = input.interpolated.fogFactorAndVertexLight.yzw;
     inputData.bakedGI = half3(0, 0, 0); // No GI currently.
-    inputData.bakedGI_directionWS = half3(0,0,0);
+    inputData.bakedGI_directionWS = half4(0,0,0,0);
 }
 
 half4 SpeedTree8Frag(SpeedTreeFragmentInput input) : SV_Target

--- a/com.unity.render-pipelines.universal/Shaders/Nature/SpeedTree8Passes.hlsl
+++ b/com.unity.render-pipelines.universal/Shaders/Nature/SpeedTree8Passes.hlsl
@@ -291,7 +291,7 @@ void InitializeInputData(SpeedTreeFragmentInput input, half3 normalTS, out Input
     inputData.fogCoord = input.interpolated.fogFactorAndVertexLight.x;
     inputData.vertexLighting = input.interpolated.fogFactorAndVertexLight.yzw;
     inputData.bakedGI = half3(0, 0, 0); // No GI currently.
-    inputData.bakedGI_directionWS = half4(0,0,0,0);
+    inputData.bakedGI_directionWS = half3(0,0,0);
 }
 
 half4 SpeedTree8Frag(SpeedTreeFragmentInput input) : SV_Target

--- a/com.unity.render-pipelines.universal/Shaders/SimpleLitForwardPass.hlsl
+++ b/com.unity.render-pipelines.universal/Shaders/SimpleLitForwardPass.hlsl
@@ -69,7 +69,7 @@ void InitializeInputData(Varyings input, half3 normalTS, out InputData inputData
     inputData.fogCoord = input.fogFactorAndVertexLight.x;
     inputData.vertexLighting = input.fogFactorAndVertexLight.yzw;
     inputData.bakedGI = SAMPLE_GI(input.lightmapUV, input.vertexSH, inputData.normalWS);
-    inputData.bakedGI_directionWS = half4(0,0,0,0);
+    inputData.bakedGI_directionWS = half3(0,0,0);
 }
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/com.unity.render-pipelines.universal/Shaders/SimpleLitForwardPass.hlsl
+++ b/com.unity.render-pipelines.universal/Shaders/SimpleLitForwardPass.hlsl
@@ -69,6 +69,7 @@ void InitializeInputData(Varyings input, half3 normalTS, out InputData inputData
     inputData.fogCoord = input.fogFactorAndVertexLight.x;
     inputData.vertexLighting = input.fogFactorAndVertexLight.yzw;
     inputData.bakedGI = SAMPLE_GI(input.lightmapUV, input.vertexSH, inputData.normalWS);
+    inputData.bakedGI_directionWS = half3(0,0,0);
 }
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/com.unity.render-pipelines.universal/Shaders/SimpleLitForwardPass.hlsl
+++ b/com.unity.render-pipelines.universal/Shaders/SimpleLitForwardPass.hlsl
@@ -69,7 +69,7 @@ void InitializeInputData(Varyings input, half3 normalTS, out InputData inputData
     inputData.fogCoord = input.fogFactorAndVertexLight.x;
     inputData.vertexLighting = input.fogFactorAndVertexLight.yzw;
     inputData.bakedGI = SAMPLE_GI(input.lightmapUV, input.vertexSH, inputData.normalWS);
-    inputData.bakedGI_directionWS = half3(0,0,0);
+    inputData.bakedGI_directionWS = half4(0,0,0,0);
 }
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/com.unity.render-pipelines.universal/Shaders/Terrain/WavingGrassPasses.hlsl
+++ b/com.unity.render-pipelines.universal/Shaders/Terrain/WavingGrassPasses.hlsl
@@ -56,7 +56,7 @@ void InitializeInputData(GrassVertexOutput input, out InputData inputData)
     inputData.fogCoord = input.fogFactorAndVertexLight.x;
     inputData.vertexLighting = input.fogFactorAndVertexLight.yzw;
     inputData.bakedGI = SAMPLE_GI(input.lightmapUV, input.vertexSH, inputData.normalWS);
-    inputData.bakedGI_directionWS = half3(0,0,0);
+    inputData.bakedGI_directionWS = half4(0,0,0,0);
 }
 
 void InitializeVertData(GrassVertexInput input, inout GrassVertexOutput vertData)

--- a/com.unity.render-pipelines.universal/Shaders/Terrain/WavingGrassPasses.hlsl
+++ b/com.unity.render-pipelines.universal/Shaders/Terrain/WavingGrassPasses.hlsl
@@ -56,6 +56,7 @@ void InitializeInputData(GrassVertexOutput input, out InputData inputData)
     inputData.fogCoord = input.fogFactorAndVertexLight.x;
     inputData.vertexLighting = input.fogFactorAndVertexLight.yzw;
     inputData.bakedGI = SAMPLE_GI(input.lightmapUV, input.vertexSH, inputData.normalWS);
+    inputData.bakedGI_directionWS = half3(0,0,0);
 }
 
 void InitializeVertData(GrassVertexInput input, inout GrassVertexOutput vertData)

--- a/com.unity.render-pipelines.universal/Shaders/Terrain/WavingGrassPasses.hlsl
+++ b/com.unity.render-pipelines.universal/Shaders/Terrain/WavingGrassPasses.hlsl
@@ -56,7 +56,7 @@ void InitializeInputData(GrassVertexOutput input, out InputData inputData)
     inputData.fogCoord = input.fogFactorAndVertexLight.x;
     inputData.vertexLighting = input.fogFactorAndVertexLight.yzw;
     inputData.bakedGI = SAMPLE_GI(input.lightmapUV, input.vertexSH, inputData.normalWS);
-    inputData.bakedGI_directionWS = half4(0,0,0,0);
+    inputData.bakedGI_directionWS = half3(0,0,0);
 }
 
 void InitializeVertData(GrassVertexInput input, inout GrassVertexOutput vertData)


### PR DESCRIPTION
This PR is incomplete but represents ongoing work I've been doing to improve the baked lighting in the URP. Baked lighting has no specular component in most baked lighting solutions, including Unity. Instead, reflection probes are used to give smooth objects some amount of reflections. However, these reflection probes look terrible because they have no understanding of objects in shadow, blindly reflecting full strength even for objects in the dark areas. 

Unity actually stores the dominant direction of the lightmap light into a secondary texture. This is currently used to properly render normals for baked objects, but we can use it to calculate the specular highlights too! 

Both normals and specular are view-dependent effects. This work is early, and needs some fixing, but even at this stage the specular helps *a lot* to making these objects feel grounded. I underestimated how much spec is used by our brains to understand the shape of things. Additionally, the specular lighting is critical to reading the bumpiness of objects. Without it, everything is going to look very flat.

![Unity_fBbsydCTuV](https://user-images.githubusercontent.com/1078792/87328122-e06ec000-c4e9-11ea-823a-ad6ce8706803.png)
![Unity_OKqNHL9052](https://user-images.githubusercontent.com/1078792/87328123-e1075680-c4e9-11ea-9fa9-53faed8f84fc.png)

These are dramatic highlights to make it clear. I think we want them subtle. We should balance them so they don't detract from the painterly feelings we're looking for.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/astrangergravity/graphics/2)
<!-- Reviewable:end -->
