### PR TITLE
Adds an option to run Tone Mapping and Color Grading in the Forward Pass.

### DIFF
--- a/com.unity.render-pipelines.core/Runtime/Volume/VolumeStack.cs
+++ b/com.unity.render-pipelines.core/Runtime/Volume/VolumeStack.cs
@@ -12,7 +12,7 @@ namespace UnityEngine.Rendering
     public sealed class VolumeStack : IDisposable
     {
         // Holds the state of _all_ component types you can possibly add on volumes
-        internal Dictionary<Type, VolumeComponent> components;
+        public Dictionary<Type, VolumeComponent> components;
 
         internal VolumeStack()
         {

--- a/com.unity.render-pipelines.universal/CHANGELOG.md
+++ b/com.unity.render-pipelines.universal/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Default color values for Lit and SimpleLit shaders changed to white due to issues with texture based workflows.
 
 ### Fixed
+- Fixed a performance problem with ShaderPreprocessor with large amount of active shader variants in the project 
 - Fixed an issue where camera stacking didn't work properly inside prefab mode. [case 1220509](https://issuetracker.unity3d.com/issues/urp-cannot-assign-overlay-cameras-to-a-camera-stack-while-in-prefab-mode)
 - Fixed a material leak on domain reload.
 - Fixed NaNs in tonemap algorithms (neutral and ACES) on Nintendo Switch.

--- a/com.unity.render-pipelines.universal/Editor/ShaderGraph/Includes/PBRForwardPass.hlsl
+++ b/com.unity.render-pipelines.universal/Editor/ShaderGraph/Includes/PBRForwardPass.hlsl
@@ -29,6 +29,22 @@
     inputData.fogCoord = input.fogFactorAndVertexLight.x;
     inputData.vertexLighting = input.fogFactorAndVertexLight.yzw;
     inputData.bakedGI = SAMPLE_GI(input.lightmapUV, input.sh, inputData.normalWS);
+
+#ifdef LIGHTMAP_ON
+    half2 uv = input.lightmapUV;
+
+    // TODO(fixforship): This adds an *additional* unnecessary texture fetch to the shader. We're already sampling
+    // the directional lightmap in the SAMPLE_GI function, so we should sample it first, and feed it
+    // in, instead.
+    real4 direction_raw = SAMPLE_TEXTURE2D(unity_LightmapInd, samplerunity_Lightmap, uv);
+    half3 direction = (direction_raw.xyz - 0.5) * 2; // convert from [0,1] to [-1,1]
+    inputData.bakedGI_directionWS = direction;
+
+#else // LIGHTMAP_ON
+
+    inputData.bakedGI_directionWS = half3(0,0,0);
+
+#endif
 }
 
 PackedVaryings vert(Attributes input)

--- a/com.unity.render-pipelines.universal/Editor/ShaderGraph/Includes/PBRForwardPass.hlsl
+++ b/com.unity.render-pipelines.universal/Editor/ShaderGraph/Includes/PBRForwardPass.hlsl
@@ -1,4 +1,20 @@
-﻿void BuildInputData(Varyings input, float3 normal, out InputData inputData)
+﻿// (ASG) Include a few post processing functions from a file. But only the functions.
+#define UNIVERSAL_POSTPROCESSING_COMMON_ONLY_INCLUDE_UTILS
+#include "Packages/com.unity.render-pipelines.universal/Shaders/PostProcessing/Common.hlsl"
+
+// (ASG) Used when tonemapping and color grading is done in the forward pass.
+#ifdef _COLOR_TRANSFORM_IN_FORWARD
+
+float4 _Lut_Params;
+float4 _UserLut_Params;
+TEXTURE2D(_UserLut);
+TEXTURE2D(_InternalLut);
+SAMPLER(sampler_LinearClamp);
+float _TestParam;
+
+#endif
+
+void BuildInputData(Varyings input, float3 normal, out InputData inputData)
 {
     inputData.positionWS = input.positionWS;
 #ifdef _NORMALMAP
@@ -88,8 +104,15 @@ half4 frag(PackedVaryings packedInput) : SV_TARGET
 			surfaceDescription.Smoothness,
 			surfaceDescription.Occlusion,
 			surfaceDescription.Emission,
-			surfaceDescription.Alpha); 
+			surfaceDescription.Alpha);
 
-    color.rgb = MixFog(color.rgb, inputData.fogCoord); 
+    color.rgb = MixFog(color.rgb, inputData.fogCoord);
+
+    // (ASG) Add tonemapping and color grading in forward pass.
+    // This uses the same color grading function as the post processing shader.
+#ifdef _COLOR_TRANSFORM_IN_FORWARD
+    color.rgb = ApplyColorGrading(color.rgb, _Lut_Params.w, TEXTURE2D_ARGS(_InternalLut, sampler_LinearClamp), _Lut_Params.xyz, TEXTURE2D_ARGS(_UserLut, sampler_LinearClamp), _UserLut_Params.xyz, _UserLut_Params.w);
+#endif
+
     return color;
 }

--- a/com.unity.render-pipelines.universal/Editor/ShaderGraph/SubShaders/UniversalPBRSubShader.cs
+++ b/com.unity.render-pipelines.universal/Editor/ShaderGraph/SubShaders/UniversalPBRSubShader.cs
@@ -86,6 +86,8 @@ namespace UnityEditor.Rendering.Universal
             },
             keywords = new KeywordDescriptor[]
             {
+                s_GradingSettings,
+                s_ColorTransformKeyword,
                 s_LightmapKeyword,
                 s_DirectionalLightmapCombinedKeyword,
                 s_MainLightShadowsKeyword,
@@ -290,6 +292,33 @@ namespace UnityEditor.Rendering.Universal
 #endregion
 
 #region Keywords
+
+        static KeywordDescriptor s_GradingSettings = new KeywordDescriptor()
+        {
+            displayName = "Grading Settings",
+            referenceName = "",
+            type = KeywordType.Enum,
+            definition = KeywordDefinition.MultiCompile,
+            scope = KeywordScope.Global,
+            entries = new KeywordEntry[]
+            {
+                // Additional underscore is prepended to referenceName
+                new KeywordEntry() { displayName = "Off", referenceName = "" }, // doesn't set any keyword
+                new KeywordEntry() { displayName = "HDR Grading", referenceName = "HDR_GRADING" },
+                new KeywordEntry() { displayName = "LDR Tonemap ACES", referenceName = "TONEMAP_ACES" },
+                new KeywordEntry() { displayName = "LDR Tonemap Neutral", referenceName = "TONEMAP_NEUTRAL" },
+            }
+        };
+
+        static KeywordDescriptor s_ColorTransformKeyword = new KeywordDescriptor()
+        {
+            displayName = "Transform Color in Forward Pass",
+            referenceName = "_COLOR_TRANSFORM_IN_FORWARD",
+            type = KeywordType.Boolean,
+            definition = KeywordDefinition.MultiCompile,
+            scope = KeywordScope.Global,
+        };
+
         static KeywordDescriptor s_LightmapKeyword = new KeywordDescriptor()
         {
             displayName = "Lightmap",

--- a/com.unity.render-pipelines.universal/Editor/ShaderPreprocessor.cs
+++ b/com.unity.render-pipelines.universal/Editor/ShaderPreprocessor.cs
@@ -8,7 +8,7 @@ using UnityEngine.Rendering;
 
 namespace UnityEditor.Rendering.Universal
 {
-    internal class ShaderPreprocessor : IPreprocessShaders
+    public class ShaderPreprocessor : IPreprocessShaders
     {
         [Flags]
         enum ShaderFeatures
@@ -45,6 +45,19 @@ namespace UnityEditor.Rendering.Universal
         // Multiple callback may be implemented.
         // The first one executed is the one where callbackOrder is returning the smallest number.
         public int callbackOrder { get { return 0; } }
+
+        /// <summary> A function returning true if the shader should be stripped. </summary>
+        public static Func<Shader, ShaderCompilerData, ShaderSnippetData, bool> CustomStrippingFunction;
+
+        bool StripCustom(Shader shader, ShaderCompilerData compilerData, ShaderSnippetData snippetData)
+        {
+            if (CustomStrippingFunction != null)
+            {
+                return CustomStrippingFunction(shader, compilerData, snippetData);
+            }
+
+            return false;
+        }
 
         bool StripUnusedShader(ShaderFeatures features, Shader shader, ShaderCompilerData compilerData)
         {
@@ -183,6 +196,9 @@ namespace UnityEditor.Rendering.Universal
                 return true;
 
             if (StripDeprecated(compilerData))
+                return true;
+
+            if (StripCustom(shader, compilerData, snippetData))
                 return true;
 
             return false;

--- a/com.unity.render-pipelines.universal/Editor/ShaderPreprocessor.cs
+++ b/com.unity.render-pipelines.universal/Editor/ShaderPreprocessor.cs
@@ -214,13 +214,22 @@ namespace UnityEditor.Rendering.Universal
 
             int prevVariantCount = compilerDataList.Count;
 
-            for (int i = 0; i < compilerDataList.Count; ++i)
+            var inputShaderVariantCount = compilerDataList.Count;
+            for (int i = 0; i < inputShaderVariantCount;)
             {
-                if (StripUnused(features, shader, snippetData, compilerDataList[i]))
-                {
+                bool removeInput = StripUnused(features, shader, snippetData, compilerDataList[i]);
+                if (removeInput)
+                    compilerDataList[i] = compilerDataList[--inputShaderVariantCount];
+                else
+                    ++i;
+            }
+
+            if(compilerDataList is List<ShaderCompilerData> inputDataList)
+                inputDataList.RemoveRange(inputShaderVariantCount, inputDataList.Count - inputShaderVariantCount);
+            else
+            {
+                for(int i = compilerDataList.Count -1; i >= inputShaderVariantCount; --i)
                     compilerDataList.RemoveAt(i);
-                    --i;
-                }
             }
 
             if (urpAsset.shaderVariantLogLevel != ShaderVariantLogLevel.Disabled)

--- a/com.unity.render-pipelines.universal/Editor/UniversalRenderPipelineAssetEditor.cs
+++ b/com.unity.render-pipelines.universal/Editor/UniversalRenderPipelineAssetEditor.cs
@@ -33,6 +33,7 @@ namespace UnityEditor.Rendering.Universal
 
             // Quality
             public static GUIContent hdrText = EditorGUIUtility.TrTextContent("HDR", "Controls the global HDR settings.");
+            public static GUIContent colorTransformationText = EditorGUIUtility.TrTextContent("Color Transformation", "If set to Forward Pass, tonemapping and color grading will be moved into the ForwardPass. This allows us to use HDR, but completely remove the final blit pass. The forward pass will render in HDR, but output to the framebuffer directly.\n\nNote: This will make transparent and blended objects render slightly incorrectly.");
             public static GUIContent msaaText = EditorGUIUtility.TrTextContent("Anti Aliasing (MSAA)", "Controls the global anti aliasing settings.");
             public static GUIContent renderScaleText = EditorGUIUtility.TrTextContent("Render Scale", "Scales the camera render target allowing the game to render at a resolution different than native resolution. UI is always rendered at native resolution. When VR is enabled, this is overridden by XRSettings.");
 
@@ -104,6 +105,7 @@ namespace UnityEditor.Rendering.Universal
         SerializedProperty m_SupportsTerrainHolesProp;
 
         SerializedProperty m_HDR;
+        SerializedProperty m_ColorTransformation;
         SerializedProperty m_MSAA;
         SerializedProperty m_RenderScale;
 
@@ -172,6 +174,7 @@ namespace UnityEditor.Rendering.Universal
             m_SupportsTerrainHolesProp = serializedObject.FindProperty("m_SupportsTerrainHoles");
 
             m_HDR = serializedObject.FindProperty("m_SupportsHDR");
+            m_ColorTransformation = serializedObject.FindProperty("m_ColorTransformation");
             m_MSAA = serializedObject.FindProperty("m_MSAA");
             m_RenderScale = serializedObject.FindProperty("m_RenderScale");
 
@@ -248,6 +251,7 @@ namespace UnityEditor.Rendering.Universal
             {
                 EditorGUI.indentLevel++;
                 EditorGUILayout.PropertyField(m_HDR, Styles.hdrText);
+                EditorGUILayout.PropertyField(m_ColorTransformation, Styles.colorTransformationText);
                 EditorGUILayout.PropertyField(m_MSAA, Styles.msaaText);
                 EditorGUI.BeginDisabledGroup(XRGraphics.enabled);
                 m_RenderScale.floatValue = EditorGUILayout.Slider(Styles.renderScaleText, m_RenderScale.floatValue, UniversalRenderPipeline.minRenderScale, UniversalRenderPipeline.maxRenderScale);

--- a/com.unity.render-pipelines.universal/Runtime/Data/UniversalRenderPipelineAsset.cs
+++ b/com.unity.render-pipelines.universal/Runtime/Data/UniversalRenderPipelineAsset.cs
@@ -111,6 +111,27 @@ namespace UnityEngine.Rendering.Universal
         HighDynamicRange
     }
 
+    // (ASG)
+    /// <summary>
+    /// Where to do tone-mapping and color grading.
+    /// </summary>
+    public enum ColorTransformation
+    {
+        /// <summary>
+        /// Performs color transformation just before the final output of the ForwardPass shader.
+        /// </summary>
+        /// <remarks>
+        /// This may cause issues with accuracy and blended objects will be blended incorrectly.
+        /// However, it allows us to avoid an extra PostProcess fullscreen blit pass, if it's not otherwise needed.
+        /// </remarks>
+        InForwardPass,
+
+        /// <summary>
+        /// Default: Performs the color transformation as a post processing pass. This is how the non-ASG URP does it.
+        /// </summary>
+        InPostProcessing
+    }
+
     /// <summary>
     /// The available post-processing solutions to use for the project. To future proof your
     /// application, use <see cref="Integrated"/> instead of the comparability mode. Only use
@@ -159,6 +180,7 @@ namespace UnityEngine.Rendering.Universal
 
         // Quality settings
         [SerializeField] bool m_SupportsHDR = false;
+        [SerializeField] ColorTransformation m_ColorTransformation = ColorTransformation.InPostProcessing;
         [SerializeField] MsaaQuality m_MSAA = MsaaQuality.Disabled;
         [SerializeField] float m_RenderScale = 1.0f;
         // TODO: Shader Quality Tiers
@@ -546,6 +568,12 @@ namespace UnityEngine.Rendering.Universal
         {
             get { return m_SupportsHDR; }
             set { m_SupportsHDR = value; }
+        }
+
+        public ColorTransformation colorTransformation
+        {
+            get { return m_ColorTransformation; }
+            set { m_ColorTransformation = value; }
         }
 
         public int msaaSampleCount

--- a/com.unity.render-pipelines.universal/Runtime/ForwardRenderer.cs
+++ b/com.unity.render-pipelines.universal/Runtime/ForwardRenderer.cs
@@ -545,7 +545,9 @@ namespace UnityEngine.Rendering.Universal
             if (isOffscreenRender)
                 return requiresBlitForOffscreenCamera;
 
-            return requiresBlitForOffscreenCamera || cameraData.isSceneViewCamera || isScaledRender || cameraData.isHdrEnabled ||
+            bool colorTransformInPost = UniversalRenderPipeline.asset.colorTransformation == ColorTransformation.InPostProcessing;
+
+            return requiresBlitForOffscreenCamera || cameraData.isSceneViewCamera || isScaledRender || (cameraData.isHdrEnabled && colorTransformInPost) ||
                    !isCompatibleBackbufferTextureDimension || !cameraData.isDefaultViewport || isCapturing ||
                    (Display.main.requiresBlitToBackbuffer && !isStereoEnabled);
         }

--- a/com.unity.render-pipelines.universal/Runtime/ForwardRenderer.cs
+++ b/com.unity.render-pipelines.universal/Runtime/ForwardRenderer.cs
@@ -1,3 +1,4 @@
+using UnityEngine.Profiling;
 using UnityEngine.Rendering.Universal.Internal;
 
 namespace UnityEngine.Rendering.Universal
@@ -128,10 +129,6 @@ namespace UnityEngine.Rendering.Universal
         /// <inheritdoc />
         public override void Setup(ScriptableRenderContext context, ref RenderingData renderingData)
         {
-            if (UniversalRenderPipeline.asset.colorTransformation == ColorTransformation.InForwardPass)
-            {
-                Shader.EnableKeyword("_COLOR_TRANSFORM_IN_FORWARD");
-            }
 
             Camera camera = renderingData.cameraData.camera;
             ref CameraData cameraData = ref renderingData.cameraData;
@@ -149,15 +146,17 @@ namespace UnityEngine.Rendering.Universal
                         rendererFeatures[i].AddRenderPasses(this, ref renderingData);
                 }
 
+                m_RenderOpaqueForwardPass.Setup();
                 EnqueuePass(m_RenderOpaqueForwardPass);
                 EnqueuePass(m_DrawSkyboxPass);
+                m_RenderTransparentForwardPass.Setup();
                 EnqueuePass(m_RenderTransparentForwardPass);
                 return;
             }
 
             // Should apply post-processing after rendering this camera?
             // (ASG) And are there any post process effects *actually* active?
-            bool applyPostProcessing = cameraData.postProcessEnabled && m_PostProcessPass.AnyEffectsRequireSeparatePass();
+            bool applyPostProcessing = cameraData.postProcessEnabled && !CanSkipSeparatePostProcessPass();
 
             // There's at least a camera in the camera stack that applies post-processing
             bool anyPostProcessing = renderingData.postProcessingEnabled;
@@ -264,6 +263,8 @@ namespace UnityEngine.Rendering.Universal
                 EnqueuePass(m_ColorGradingLutPass);
             }
 
+            m_RenderOpaqueForwardPass.Setup(m_ColorGradingLut, generateColorGradingLUT);
+
             EnqueuePass(m_RenderOpaqueForwardPass);
 
 #if POST_PROCESSING_STACK_2_0_0_OR_NEWER
@@ -305,6 +306,7 @@ namespace UnityEngine.Rendering.Universal
                 EnqueuePass(m_TransparentSettingsPass);
             }
 
+            m_RenderTransparentForwardPass.Setup(m_ColorGradingLut, generateColorGradingLUT);
             EnqueuePass(m_RenderTransparentForwardPass);
             EnqueuePass(m_OnRenderObjectCallbackPass);
 
@@ -576,5 +578,50 @@ namespace UnityEngine.Rendering.Universal
             bool msaaDepthResolve = false;
             return supportsDepthCopy || msaaDepthResolve;
         }
+
+        // (ASG)
+        /// <summary>
+        /// Some effects like tonemap and color grading can be applied in the ForwardPass without needing a separate
+        /// post process shader. This function returns whether all active post-processing effects are compatible to be
+        /// run in the ForwardPass.
+        /// </summary>
+        /// <remarks>Expensive, because we re-query the effects stack. Don't run more than once.</remarks>
+        public bool CanSkipSeparatePostProcessPass()
+        {
+            if (UniversalRenderPipeline.asset.colorTransformation != ColorTransformation.InForwardPass)
+            {
+                return false;
+            }
+
+            var stack = VolumeManager.instance.stack;
+
+            // We can skip the post process pass if only forward effects are activated.
+            // Note: This doesn't allocate. I've profiled it, on desktop. (john)
+            foreach (var type in stack.components.Keys)
+            {
+                if (!(
+                    type == typeof(ChannelMixer) ||
+                    type == typeof(ColorAdjustments) ||
+                    type == typeof(ColorCurves) ||
+                    type == typeof(ColorLookup) ||
+                    type == typeof(LiftGammaGain) ||
+                    type == typeof(ShadowsMidtonesHighlights) ||
+                    type == typeof(SplitToning) ||
+                    type == typeof(Tonemapping) ||
+                    type == typeof(WhiteBalance)))
+                {
+                    VolumeComponent component = stack.components[type];
+                    if (component.active && component is IPostProcessComponent post && post.IsActive())
+                    {
+                        // We've enabled a post effect that's not compatible with ForwardPass execution.
+                        return false;
+                    }
+                }
+            }
+
+            // All effects are either disabled or able to run on forward pass.
+            return true;
+        }
+
     }
 }

--- a/com.unity.render-pipelines.universal/Runtime/ForwardRenderer.cs
+++ b/com.unity.render-pipelines.universal/Runtime/ForwardRenderer.cs
@@ -128,6 +128,11 @@ namespace UnityEngine.Rendering.Universal
         /// <inheritdoc />
         public override void Setup(ScriptableRenderContext context, ref RenderingData renderingData)
         {
+            if (UniversalRenderPipeline.asset.colorTransformation == ColorTransformation.InForwardPass)
+            {
+                Shader.EnableKeyword("_COLOR_TRANSFORM_IN_FORWARD");
+            }
+
             Camera camera = renderingData.cameraData.camera;
             ref CameraData cameraData = ref renderingData.cameraData;
             RenderTextureDescriptor cameraTargetDescriptor = renderingData.cameraData.cameraTargetDescriptor;

--- a/com.unity.render-pipelines.universal/Runtime/Passes/ColorGradingLutPass.cs
+++ b/com.unity.render-pipelines.universal/Runtime/Passes/ColorGradingLutPass.cs
@@ -56,6 +56,11 @@ namespace UnityEngine.Rendering.Universal.Internal
         public void Setup(in RenderTargetHandle internalLut)
         {
             m_InternalLut = internalLut;
+
+            // (ASG) This is required, otherwise this pass has the default camera attachment, and the code in
+            // ScriptableRenderer.Execute enables XR mode for this pass (when in forward color grading mode).
+            // (John): I believe this is a bug in URP, and this should be set.
+            ConfigureTarget(m_InternalLut.Identifier());
         }
 
         /// <inheritdoc/>

--- a/com.unity.render-pipelines.universal/Runtime/Passes/DrawObjectsPass.cs
+++ b/com.unity.render-pipelines.universal/Runtime/Passes/DrawObjectsPass.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using UnityEngine.Assertions;
 
 namespace UnityEngine.Rendering.Universal.Internal
 {
@@ -16,6 +17,17 @@ namespace UnityEngine.Rendering.Universal.Internal
         string m_ProfilerTag;
         ProfilingSampler m_ProfilingSampler;
         bool m_IsOpaque;
+
+        // (ASG) Adding color grading to forward pass
+        int m_lutParamsProp = Shader.PropertyToID("_Lut_Params");
+        int m_userLutParamsProp = Shader.PropertyToID("_UserLut_Params");
+        int m_userLutProp = Shader.PropertyToID("_UserLut");
+        int m_internalLutProp = Shader.PropertyToID("_InternalLut");
+        RenderTargetHandle m_internalLut;
+        ColorLookup m_ColorLookup;
+        ColorAdjustments m_ColorAdjustments;
+        Tonemapping m_Tonemapping;
+        bool m_doColorTransform = false; // whether this pass should do color grading / tonemapping
 
         public DrawObjectsPass(string profilerTag, bool opaque, RenderPassEvent evt, RenderQueueRange renderQueueRange, LayerMask layerMask, StencilState stencilState, int stencilReference)
         {
@@ -37,12 +49,82 @@ namespace UnityEngine.Rendering.Universal.Internal
             }
         }
 
+        // Sets up the pass to queue up without doing the color transform
+        public void Setup()
+        {
+            m_doColorTransform = false;
+        }
+
+        // Sets up the pass to queue up with the color transform
+        public void Setup(in RenderTargetHandle internalLut, bool generatedLutTexture)
+        {
+            m_doColorTransform = generatedLutTexture;
+
+            m_internalLut = internalLut;
+            var stack = VolumeManager.instance.stack;
+            m_ColorLookup = stack.GetComponent<ColorLookup>();
+            m_ColorAdjustments = stack.GetComponent<ColorAdjustments>();
+            m_Tonemapping = stack.GetComponent<Tonemapping>();
+        }
+
         /// <inheritdoc/>
         public override void Execute(ScriptableRenderContext context, ref RenderingData renderingData)
         {
             CommandBuffer cmd = CommandBufferPool.Get(m_ProfilerTag);
             using (new ProfilingScope(cmd, m_ProfilingSampler))
             {
+                // (ASG) Feed the color grading and tonemapping information into the shader
+                if (UniversalRenderPipeline.asset.colorTransformation == ColorTransformation.InForwardPass &&
+                    m_doColorTransform)
+                {
+                    cmd.EnableShaderKeyword("_COLOR_TRANSFORM_IN_FORWARD");
+
+                    // Post exposure is controlled non-linearly for better artistic control.
+                    ref var postProcessingData = ref renderingData.postProcessingData;
+
+                    int lutHeight = postProcessingData.lutSize;
+                    int lutWidth = lutHeight * lutHeight;
+                    float postExposureLinear = Mathf.Pow(2f, m_ColorAdjustments.postExposure.value);
+                    cmd.SetGlobalTexture(m_internalLutProp, m_internalLut.Identifier());
+                    cmd.SetGlobalVector(m_lutParamsProp,
+                        new Vector4(1f / lutWidth, 1f / lutHeight, lutHeight - 1f, postExposureLinear));
+
+                    if (m_ColorLookup.IsActive())
+                    {
+                        cmd.SetGlobalTexture(m_userLutProp, m_ColorLookup.texture.value);
+                        cmd.SetGlobalVector(m_userLutParamsProp, new Vector4(1, 0, 0, 1));
+                    }
+
+                    // (ASG) Note: in HDR grading mode, tonemapping is done via the LUT, so no keywords are set.
+                    if (postProcessingData.gradingMode == ColorGradingMode.HighDynamicRange)
+                    {
+                        cmd.EnableShaderKeyword(ShaderKeywordStrings.HDRGrading);
+                    }
+                    else
+                    {
+                        cmd.DisableShaderKeyword(ShaderKeywordStrings.HDRGrading);
+                        switch (m_Tonemapping.mode.value)
+                        {
+                            case TonemappingMode.Neutral:
+                                cmd.DisableShaderKeyword(ShaderKeywordStrings.TonemapACES);
+                                cmd.EnableShaderKeyword(ShaderKeywordStrings.TonemapNeutral);
+                                break;
+                            case TonemappingMode.ACES:
+                                cmd.DisableShaderKeyword(ShaderKeywordStrings.TonemapNeutral);
+                                cmd.EnableShaderKeyword(ShaderKeywordStrings.TonemapACES);
+                                break;
+                            default:  // None
+                                cmd.DisableShaderKeyword(ShaderKeywordStrings.TonemapNeutral);
+                                cmd.DisableShaderKeyword(ShaderKeywordStrings.TonemapACES);
+                                break;
+                        }
+                    }
+                }
+                else
+                {
+                    cmd.DisableShaderKeyword("_COLOR_TRANSFORM_IN_FORWARD");
+                }
+
                 context.ExecuteCommandBuffer(cmd);
                 cmd.Clear();
 

--- a/com.unity.render-pipelines.universal/Runtime/Passes/PostProcessPass.cs
+++ b/com.unity.render-pipelines.universal/Runtime/Passes/PostProcessPass.cs
@@ -116,6 +116,49 @@ namespace UnityEngine.Rendering.Universal.Internal
 
         public void Cleanup() => m_Materials.Cleanup();
 
+        // (ASG)
+        /// <summary>
+        /// Whether any effects require a separate Post Processing pass. Some effects like tonemap and color grading
+        /// can be applied in the ForwardPass without needing a separate post process shader.
+        /// </summary>
+        /// <remarks>Expensive, because we re-query the effects stack. Don't run more than once.</remarks>
+        public bool AnyEffectsRequireSeparatePass()
+        {
+            CacheEffects();
+            return
+                m_DepthOfField.IsActive() ||
+                m_MotionBlur.IsActive() ||
+                m_PaniniProjection.IsActive() ||
+                m_Bloom.IsActive() ||
+                m_LensDistortion.IsActive() ||
+                m_ChromaticAberration.IsActive() ||
+                m_Vignette.IsActive() ||
+                m_FilmGrain.IsActive() ||
+                // These effects are only active if color transformation happens in post.
+                (UniversalRenderPipeline.asset.colorTransformation == ColorTransformation.InPostProcessing && (
+                    m_ColorAdjustments.IsActive() ||
+                    m_ColorLookup.IsActive() ||
+                    m_Tonemapping.IsActive()));
+        }
+
+        private void CacheEffects()
+        {
+            // Start by pre-fetching all builtin effect settings we need
+            // Some of the color-grading settings are only used in the color grading lut pass
+            var stack = VolumeManager.instance.stack;
+            m_DepthOfField        = stack.GetComponent<DepthOfField>();
+            m_MotionBlur          = stack.GetComponent<MotionBlur>();
+            m_PaniniProjection    = stack.GetComponent<PaniniProjection>();
+            m_Bloom               = stack.GetComponent<Bloom>();
+            m_LensDistortion      = stack.GetComponent<LensDistortion>();
+            m_ChromaticAberration = stack.GetComponent<ChromaticAberration>();
+            m_Vignette            = stack.GetComponent<Vignette>();
+            m_ColorLookup         = stack.GetComponent<ColorLookup>();
+            m_ColorAdjustments    = stack.GetComponent<ColorAdjustments>();
+            m_Tonemapping         = stack.GetComponent<Tonemapping>();
+            m_FilmGrain           = stack.GetComponent<FilmGrain>();
+        }
+
         public void Setup(in RenderTextureDescriptor baseDescriptor, in RenderTargetHandle source, in RenderTargetHandle destination, in RenderTargetHandle depth, in RenderTargetHandle internalLut, bool hasFinalPass, bool enableSRGBConversion)
         {
             m_Descriptor = baseDescriptor;
@@ -126,6 +169,8 @@ namespace UnityEngine.Rendering.Universal.Internal
             m_IsFinalPass = false;
             m_HasFinalPass = hasFinalPass;
             m_EnableSRGBConversionIfNeeded = enableSRGBConversion;
+
+            CacheEffects();
         }
 
         public void SetupFinalPass(in RenderTargetHandle source)
@@ -135,6 +180,8 @@ namespace UnityEngine.Rendering.Universal.Internal
             m_IsFinalPass = true;
             m_HasFinalPass = false;
             m_EnableSRGBConversionIfNeeded = true;
+
+            CacheEffects();
         }
 
         public override void Configure(CommandBuffer cmd, RenderTextureDescriptor cameraTextureDescriptor)
@@ -162,20 +209,6 @@ namespace UnityEngine.Rendering.Universal.Internal
         /// <inheritdoc/>
         public override void Execute(ScriptableRenderContext context, ref RenderingData renderingData)
         {
-            // Start by pre-fetching all builtin effect settings we need
-            // Some of the color-grading settings are only used in the color grading lut pass
-            var stack = VolumeManager.instance.stack;
-            m_DepthOfField        = stack.GetComponent<DepthOfField>();
-            m_MotionBlur          = stack.GetComponent<MotionBlur>();
-            m_PaniniProjection    = stack.GetComponent<PaniniProjection>();
-            m_Bloom               = stack.GetComponent<Bloom>();
-            m_LensDistortion      = stack.GetComponent<LensDistortion>();
-            m_ChromaticAberration = stack.GetComponent<ChromaticAberration>();
-            m_Vignette            = stack.GetComponent<Vignette>();
-            m_ColorLookup         = stack.GetComponent<ColorLookup>();
-            m_ColorAdjustments    = stack.GetComponent<ColorAdjustments>();
-            m_Tonemapping         = stack.GetComponent<Tonemapping>();
-            m_FilmGrain           = stack.GetComponent<FilmGrain>();
 
             if (m_IsFinalPass)
             {

--- a/com.unity.render-pipelines.universal/Runtime/Passes/PostProcessPass.cs
+++ b/com.unity.render-pipelines.universal/Runtime/Passes/PostProcessPass.cs
@@ -116,25 +116,6 @@ namespace UnityEngine.Rendering.Universal.Internal
 
         public void Cleanup() => m_Materials.Cleanup();
 
-
-        private void CacheEffects()
-        {
-            // Start by pre-fetching all builtin effect settings we need
-            // Some of the color-grading settings are only used in the color grading lut pass
-            var stack = VolumeManager.instance.stack;
-            m_DepthOfField        = stack.GetComponent<DepthOfField>();
-            m_MotionBlur          = stack.GetComponent<MotionBlur>();
-            m_PaniniProjection    = stack.GetComponent<PaniniProjection>();
-            m_Bloom               = stack.GetComponent<Bloom>();
-            m_LensDistortion      = stack.GetComponent<LensDistortion>();
-            m_ChromaticAberration = stack.GetComponent<ChromaticAberration>();
-            m_Vignette            = stack.GetComponent<Vignette>();
-            m_ColorLookup         = stack.GetComponent<ColorLookup>();
-            m_ColorAdjustments    = stack.GetComponent<ColorAdjustments>();
-            m_Tonemapping         = stack.GetComponent<Tonemapping>();
-            m_FilmGrain           = stack.GetComponent<FilmGrain>();
-        }
-
         public void Setup(in RenderTextureDescriptor baseDescriptor, in RenderTargetHandle source, in RenderTargetHandle destination, in RenderTargetHandle depth, in RenderTargetHandle internalLut, bool hasFinalPass, bool enableSRGBConversion)
         {
             m_Descriptor = baseDescriptor;
@@ -145,8 +126,6 @@ namespace UnityEngine.Rendering.Universal.Internal
             m_IsFinalPass = false;
             m_HasFinalPass = hasFinalPass;
             m_EnableSRGBConversionIfNeeded = enableSRGBConversion;
-
-            CacheEffects();
         }
 
         public void SetupFinalPass(in RenderTargetHandle source)
@@ -156,8 +135,6 @@ namespace UnityEngine.Rendering.Universal.Internal
             m_IsFinalPass = true;
             m_HasFinalPass = false;
             m_EnableSRGBConversionIfNeeded = true;
-
-            CacheEffects();
         }
 
         public override void Configure(CommandBuffer cmd, RenderTextureDescriptor cameraTextureDescriptor)
@@ -185,6 +162,20 @@ namespace UnityEngine.Rendering.Universal.Internal
         /// <inheritdoc/>
         public override void Execute(ScriptableRenderContext context, ref RenderingData renderingData)
         {
+            // Start by pre-fetching all builtin effect settings we need
+            // Some of the color-grading settings are only used in the color grading lut pass
+            var stack = VolumeManager.instance.stack;
+            m_DepthOfField        = stack.GetComponent<DepthOfField>();
+            m_MotionBlur          = stack.GetComponent<MotionBlur>();
+            m_PaniniProjection    = stack.GetComponent<PaniniProjection>();
+            m_Bloom               = stack.GetComponent<Bloom>();
+            m_LensDistortion      = stack.GetComponent<LensDistortion>();
+            m_ChromaticAberration = stack.GetComponent<ChromaticAberration>();
+            m_Vignette            = stack.GetComponent<Vignette>();
+            m_ColorLookup         = stack.GetComponent<ColorLookup>();
+            m_ColorAdjustments    = stack.GetComponent<ColorAdjustments>();
+            m_Tonemapping         = stack.GetComponent<Tonemapping>();
+            m_FilmGrain           = stack.GetComponent<FilmGrain>();
 
             if (m_IsFinalPass)
             {
@@ -266,7 +257,7 @@ namespace UnityEngine.Rendering.Universal.Internal
                     // Avoid using m_Source.id as new destination, it may come with a depth buffer that we don't want, may have MSAA that we don't want etc
                     cmd.GetTemporaryRT(ShaderConstants._TempTarget2, GetStereoCompatibleDescriptor(), FilterMode.Bilinear);
                     destination = ShaderConstants._TempTarget2;
-                    tempTarget2Used = true; 
+                    tempTarget2Used = true;
                 }
 
                 return destination;

--- a/com.unity.render-pipelines.universal/Runtime/Passes/PostProcessPass.cs
+++ b/com.unity.render-pipelines.universal/Runtime/Passes/PostProcessPass.cs
@@ -116,30 +116,6 @@ namespace UnityEngine.Rendering.Universal.Internal
 
         public void Cleanup() => m_Materials.Cleanup();
 
-        // (ASG)
-        /// <summary>
-        /// Whether any effects require a separate Post Processing pass. Some effects like tonemap and color grading
-        /// can be applied in the ForwardPass without needing a separate post process shader.
-        /// </summary>
-        /// <remarks>Expensive, because we re-query the effects stack. Don't run more than once.</remarks>
-        public bool AnyEffectsRequireSeparatePass()
-        {
-            CacheEffects();
-            return
-                m_DepthOfField.IsActive() ||
-                m_MotionBlur.IsActive() ||
-                m_PaniniProjection.IsActive() ||
-                m_Bloom.IsActive() ||
-                m_LensDistortion.IsActive() ||
-                m_ChromaticAberration.IsActive() ||
-                m_Vignette.IsActive() ||
-                m_FilmGrain.IsActive() ||
-                // These effects are only active if color transformation happens in post.
-                (UniversalRenderPipeline.asset.colorTransformation == ColorTransformation.InPostProcessing && (
-                    m_ColorAdjustments.IsActive() ||
-                    m_ColorLookup.IsActive() ||
-                    m_Tonemapping.IsActive()));
-        }
 
         private void CacheEffects()
         {
@@ -1009,6 +985,16 @@ namespace UnityEngine.Rendering.Universal.Internal
 
         void SetupColorGrading(CommandBuffer cmd, ref RenderingData renderingData, Material material)
         {
+            // (ASG) Disable color transformation if we're doing it in the forward pass
+            if (UniversalRenderPipeline.asset.colorTransformation == ColorTransformation.InForwardPass)
+            {
+                material.EnableKeyword("_COLOR_TRANSFORM_IN_FORWARD");
+            }
+            else
+            {
+                material.DisableKeyword("_COLOR_TRANSFORM_IN_FORWARD");
+            }
+
             ref var postProcessingData = ref renderingData.postProcessingData;
             bool hdr = postProcessingData.gradingMode == ColorGradingMode.HighDynamicRange;
             int lutHeight = postProcessingData.lutSize;

--- a/com.unity.render-pipelines.universal/Runtime/UniversalRenderPipeline.cs
+++ b/com.unity.render-pipelines.universal/Runtime/UniversalRenderPipeline.cs
@@ -627,8 +627,10 @@ namespace UnityEngine.Rendering.Universal
             cameraData.captureActions = CameraCaptureBridge.GetCaptureActions(baseCamera);
 
             bool needsAlphaChannel = Graphics.preserveFramebufferAlpha;
+            bool useHdrCameraTarget = cameraData.isHdrEnabled &&
+                                      settings.colorTransformation != ColorTransformation.InForwardPass;
             cameraData.cameraTargetDescriptor = CreateRenderTextureDescriptor(baseCamera, cameraData.renderScale,
-                cameraData.isStereoEnabled, cameraData.isHdrEnabled, msaaSamples, needsAlphaChannel);
+                cameraData.isStereoEnabled, useHdrCameraTarget, msaaSamples, needsAlphaChannel);
         }
 
         /// <summary>

--- a/com.unity.render-pipelines.universal/Shaders/Lit.shader
+++ b/com.unity.render-pipelines.universal/Shaders/Lit.shader
@@ -98,6 +98,7 @@ Shader "Universal Render Pipeline/Lit"
 
             // (ASG)
             #pragma multi_compile _ _COLOR_TRANSFORM_IN_FORWARD
+            #pragma multi_compile _ _HDR_GRADING _TONEMAP_ACES _TONEMAP_NEUTRAL
 
             // -------------------------------------
             // Universal Pipeline keywords

--- a/com.unity.render-pipelines.universal/Shaders/Lit.shader
+++ b/com.unity.render-pipelines.universal/Shaders/Lit.shader
@@ -98,6 +98,7 @@ Shader "Universal Render Pipeline/Lit"
 
             // (ASG)
             #pragma multi_compile _ _COLOR_TRANSFORM_IN_FORWARD
+            // If HDR_GRADING is on, then the tonemap algorithm is encoded in the HDR LUT
             #pragma multi_compile _ _HDR_GRADING _TONEMAP_ACES _TONEMAP_NEUTRAL
 
             // -------------------------------------

--- a/com.unity.render-pipelines.universal/Shaders/Lit.shader
+++ b/com.unity.render-pipelines.universal/Shaders/Lit.shader
@@ -96,6 +96,9 @@ Shader "Universal Render Pipeline/Lit"
             #pragma shader_feature _SPECULAR_SETUP
             #pragma shader_feature _RECEIVE_SHADOWS_OFF
 
+            // (ASG)
+            #pragma multi_compile _ _COLOR_TRANSFORM_IN_FORWARD
+
             // -------------------------------------
             // Universal Pipeline keywords
             #pragma multi_compile _ _MAIN_LIGHT_SHADOWS

--- a/com.unity.render-pipelines.universal/Shaders/LitForwardPass.hlsl
+++ b/com.unity.render-pipelines.universal/Shaders/LitForwardPass.hlsl
@@ -4,6 +4,10 @@
 #include "Packages/com.unity.render-pipelines.core/ShaderLibrary/Color.hlsl"
 #include "Packages/com.unity.render-pipelines.universal/ShaderLibrary/Lighting.hlsl"
 
+// (ASG) Include a few post processing functions from a file. But only the functions.
+#define UNIVERSAL_POSTPROCESSING_COMMON_ONLY_INCLUDE_UTILS
+#include "Packages/com.unity.render-pipelines.universal/Shaders/PostProcessing/Common.hlsl"
+
 struct Attributes
 {
     float4 positionOS   : POSITION;
@@ -125,15 +129,6 @@ Varyings LitPassVertex(Attributes input)
     return output;
 }
 
-// (ASG) Borrowed from Shaders/PostProcessing/UberPost.hlsl
-// Apply tonemapping to the input HDR color. Output is sRGB.
-half3 ApplyTonemap(half3 input)
-{
-    float3 aces = unity_to_ACES(input);
-    input = AcesTonemap(aces);
-    return saturate(input);
-}
-
 // Used in Standard (Physically Based) shader
 half4 LitPassFragment(Varyings input) : SV_Target
 {
@@ -150,9 +145,10 @@ half4 LitPassFragment(Varyings input) : SV_Target
 
     color.rgb = MixFog(color.rgb, inputData.fogCoord);
 
-    // Add tonemapping and color grading in forward pass.
+    // (ASG) Add tonemapping and color grading in forward pass.
+    // This uses the same color grading function as the post processing shader.
 #ifdef _COLOR_TRANSFORM_IN_FORWARD
-    color.rgb = ApplyTonemap(color.rgb);
+    color.rgb = ApplyColorGrading(color.rgb, _Lut_Params.w, TEXTURE2D_ARGS(_InternalLut, sampler_LinearClamp), _Lut_Params.xyz, TEXTURE2D_ARGS(_UserLut, sampler_LinearClamp), _UserLut_Params.xyz, _UserLut_Params.w);
 #endif
 
     // Return linear color. Conversion to sRGB happens automatically through the target texture format.

--- a/com.unity.render-pipelines.universal/Shaders/LitInput.hlsl
+++ b/com.unity.render-pipelines.universal/Shaders/LitInput.hlsl
@@ -18,7 +18,7 @@ half _OcclusionStrength;
 CBUFFER_END
 
 // (ASG) Used when tonemapping and color grading is done in the forward pass.
-//#ifdef _COLOR_TRANSFORM_IN_FORWARD
+#ifdef _COLOR_TRANSFORM_IN_FORWARD
 
 float4 _Lut_Params;
 float4 _UserLut_Params;
@@ -27,7 +27,7 @@ TEXTURE2D(_InternalLut);
 SAMPLER(sampler_LinearClamp);
 float _TestParam;
 
-//#endif
+#endif
 
 TEXTURE2D(_OcclusionMap);       SAMPLER(sampler_OcclusionMap);
 TEXTURE2D(_MetallicGlossMap);   SAMPLER(sampler_MetallicGlossMap);

--- a/com.unity.render-pipelines.universal/Shaders/LitInput.hlsl
+++ b/com.unity.render-pipelines.universal/Shaders/LitInput.hlsl
@@ -17,6 +17,18 @@ half _BumpScale;
 half _OcclusionStrength;
 CBUFFER_END
 
+// (ASG) Used when tonemapping and color grading is done in the forward pass.
+//#ifdef _COLOR_TRANSFORM_IN_FORWARD
+
+float4 _Lut_Params;
+float4 _UserLut_Params;
+TEXTURE2D(_UserLut);
+TEXTURE2D(_InternalLut);
+SAMPLER(sampler_LinearClamp);
+float _TestParam;
+
+//#endif
+
 TEXTURE2D(_OcclusionMap);       SAMPLER(sampler_OcclusionMap);
 TEXTURE2D(_MetallicGlossMap);   SAMPLER(sampler_MetallicGlossMap);
 TEXTURE2D(_SpecGlossMap);       SAMPLER(sampler_SpecGlossMap);

--- a/com.unity.render-pipelines.universal/Shaders/PostProcessing/Common.hlsl
+++ b/com.unity.render-pipelines.universal/Shaders/PostProcessing/Common.hlsl
@@ -131,7 +131,12 @@ half3 ApplyColorGrading(half3 input, float postExposure, TEXTURE2D_PARAM(lutTex,
     //   - Apply internal linear LUT
     #else
     {
-        input = ApplyTonemap(input);
+        // (ASG) Don't apply tonemapping here if we've already applied it in the forward pass.
+        #if !_COLOR_TRANSFORM_IN_FORWARD
+        {
+            input = ApplyTonemap(input);
+        }
+        #endif
 
         UNITY_BRANCH
         if (userLutContrib > 0.0)

--- a/com.unity.render-pipelines.universal/Shaders/PostProcessing/Common.hlsl
+++ b/com.unity.render-pipelines.universal/Shaders/PostProcessing/Common.hlsl
@@ -6,6 +6,10 @@
 // ----------------------------------------------------------------------------------
 // Common shader data used in most post-processing passes
 
+// (ASG) Allow including this file, with only the functions.
+// Note that due to the line 1 pragma, you can only include this file once as utils or with attributes.
+#ifndef UNIVERSAL_POSTPROCESSING_COMMON_ONLY_INCLUDE_UTILS
+
 struct Attributes
 {
     float4 positionOS   : POSITION;
@@ -58,6 +62,8 @@ SAMPLER(sampler_LinearClamp);
 SAMPLER(sampler_LinearRepeat);
 SAMPLER(sampler_PointClamp);
 SAMPLER(sampler_PointRepeat);
+
+#endif // UNIVERSAL_POSTPROCESSING_COMMON_ONLY_INCLUDE_UTILS
 
 // ----------------------------------------------------------------------------------
 // Utility functions
@@ -131,12 +137,7 @@ half3 ApplyColorGrading(half3 input, float postExposure, TEXTURE2D_PARAM(lutTex,
     //   - Apply internal linear LUT
     #else
     {
-        // (ASG) Don't apply tonemapping here if we've already applied it in the forward pass.
-        #if !_COLOR_TRANSFORM_IN_FORWARD
-        {
-            input = ApplyTonemap(input);
-        }
-        #endif
+        input = ApplyTonemap(input);
 
         UNITY_BRANCH
         if (userLutContrib > 0.0)

--- a/com.unity.render-pipelines.universal/Shaders/PostProcessing/UberPost.shader
+++ b/com.unity.render-pipelines.universal/Shaders/PostProcessing/UberPost.shader
@@ -1,7 +1,10 @@
 Shader "Hidden/Universal Render Pipeline/UberPost"
 {
     HLSLINCLUDE
-        
+
+        // (ASG)
+        #pragma multi_compile _ _COLOR_TRANSFORM_IN_FORWARD
+
         #pragma multi_compile_local _ _DISTORTION
         #pragma multi_compile_local _ _CHROMATIC_ABERRATION
         #pragma multi_compile_local _ _BLOOM_LQ _BLOOM_HQ _BLOOM_LQ_DIRT _BLOOM_HQ_DIRT

--- a/com.unity.render-pipelines.universal/Shaders/PostProcessing/UberPost.shader
+++ b/com.unity.render-pipelines.universal/Shaders/PostProcessing/UberPost.shader
@@ -193,10 +193,13 @@ Shader "Hidden/Universal Render Pipeline/UberPost"
                 color = ApplyVignette(color, uvDistorted, VignetteCenter, VignetteIntensity, VignetteRoundness, VignetteSmoothness, VignetteColor);
             }
 
-            // Color grading is always enabled when post-processing/uber is active
+            // (ASG) Don't apply tonemapping/color grading if we've already applied it in the forward pass.
+            #if !_COLOR_TRANSFORM_IN_FORWARD
             {
+                // (ASG) Color grading does not have a specific keyword toggle. It's always on, unless it's been moved to the forward pass.
                 color = ApplyColorGrading(color, PostExposure, TEXTURE2D_ARGS(_InternalLut, sampler_LinearClamp), LutParams, TEXTURE2D_ARGS(_UserLut, sampler_LinearClamp), UserLutParams, UserLutContribution);
             }
+            #endif
 
             #if _FILM_GRAIN
             {


### PR DESCRIPTION
This is the minimal change to move a variety of post effects to the Lit forward pass of the Universal Render Pipeline. This allows us to use a full HDR pipeline, with tonemapping, HDR color grading, etc, without running a separate Post Processing pass. 

This separate pass is too expensive to run on mobile chipsets because on those systems, reading from a render texture is *very* slow. It has to flush the memory out of the tiles and back into system memory, to be read in as an input. Doing this within a single frame is a big waste of time. See these references:
https://developer.qualcomm.com/download/adrenosdk/adreno-opengl-es-developer-guide.pdf
https://developer.oculus.com/blog/carmacks-critiques-graphics-optimization-for-gear-vr/?locale=en_US

Luckily almost all color grading effects are done via a Lookup Table in the URP. So we get all of the color post effects for free by implementing a toggle that runs that LUT in the forward pass.

Drawbacks.
There's a reason this isn't default. It's not entirely correct:
 - This method blends transparent objects in LDR, rather than HDR. So additive particles will clamp out to white rather than passing through the tonemapper. We avoid these issues by generally avoiding additive transparency (which is a good idea in VR), and using cutout transparency when we can.
 - Other post effects like Bloom now operate in LDR, after the opaque pass. This is really rough for Bloom, because a good bloom effect really needs to know the true brightness of every pixel. Bloom *can't* be run in the Opaque pass, so if you want Bloom, this technique is a non-starter.

In the future, Vulkan supports combining multiple different shader passes, but instructing them to stay within the tiler. This should allow you to write code that looks like it has separate passes, but actually compresses them to a single tiler execution under the hood. This isn't implemented in URP yet, and would be Vulkan only.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/astrangergravity/graphics/3)
<!-- Reviewable:end -->
