### PR TITLE
Always use case-sensitive paths on Linux

### DIFF
--- a/com.unity.visualeffectgraph/Editor/Compiler/VFXCodeGenerator.cs
+++ b/com.unity.visualeffectgraph/Editor/Compiler/VFXCodeGenerator.cs
@@ -217,7 +217,7 @@ namespace UnityEditor.VFX
         {
             return Path.GetFullPath(path)
                 .TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar)
-                #if !UNITY_STANDALONE_LINUX
+                #if !UNITY_STANDALONE_LINUX && !UNITY_EDITOR_LINUX
                 .ToLowerInvariant()
                 #endif
                 ;


### PR DESCRIPTION
This addresses the recent errors we've been seeing on CI builds:
```
##[error](Null Asset) : Exception while compiling expression graph: System.IO.DirectoryNotFoundException: Could not find a part of the path "/__w/1/s/unitygraphics/com.unity.visualeffectgraph/shaders/vfxinit.template".
  at System.IO.FileStream..ctor (System.String path, System.IO.FileMode mode, System.IO.FileAccess access, System.IO.FileShare share, System.Int32 bufferSize, System.Boolean anonymous, System.IO.FileOptions options) [0x00164] in <fb001e01371b4adca20013e0ac763896>:0 
  at System.IO.FileStream..ctor (System.String path, System.IO.FileMode mode, System.IO.FileAccess access, System.IO.FileShare share, System.Int32 bufferSize, System.IO.FileOptions options, System.String msgPath, System.Boolean bFromProxy, System.Boolean useLongPath, System.Boolean checkHost) [0x00000] in <fb001e01371b4adca20013e0ac763896>:0 
  at (wrapper remoting-invoke-with-check) System.IO.FileStream..ctor(string,System.IO.FileMode,System.IO.FileAccess,System.IO.FileShare,int,System.IO.FileOptions,string,bool,bool,bool)
  at System.IO.StreamReader..ctor (System.String path, System.Text.Encoding encoding, System.Boolean detectEncodingFromByteOrderMarks, System.Int32 bufferSize, System.Boolean checkHost) [0x00067] in <fb001e01371b4adca20013e0ac763896>:0 
  at System.IO.StreamReader..ctor (System.String path, System.Text.Encoding encoding, System.Boolean detectEncodingFromByteOrderMarks, System.Int32 bufferSize) [0x00000] in <fb001e01371b4adca20013e0ac763896>:0 
  at System.IO.StreamReader..ctor (System.String path, System.Boolean detectEncodingFromByteOrderMarks) [0x0000d] in <fb001e01371b4adca20013e0ac763896>:0 
  at System.IO.StreamReader..ctor (System.String path) [0x00000] in <fb001e01371b4adca20013e0ac763896>:0 
  at (wrapper remoting-invoke-with-check) System.IO.StreamReader..ctor(string)
  at System.IO.File.ReadAllText (System.String path) [0x00000] in <fb001e01371b4adca20013e0ac763896>:0 
  at UnityEditor.VFX.VFXCodeGenerator.GetFlattenedTemplateContent (System.String path, System.Collections.Generic.List`1[T] includes, System.Collections.Generic.IEnumerable`1[T] defines, System.Collections.Generic.HashSet`1[T] dependencies) [0x00083] in /__w/1/s/UnityGraphics/com.unity.visualeffectgraph/Editor/Compiler/VFXCodeGenerator.cs:278 
  at UnityEditor.VFX.VFXCodeGenerator.Build (UnityEditor.VFX.VFXContext context, System.String templatePath, UnityEditor.VFX.VFXCompilationMode compilationMode, UnityEditor.VFX.VFXContextCompiledData contextData, System.Collections.Generic.HashSet`1[T] dependencies) [0x0001c] in /__w/1/s/UnityGraphics/com.unity.visualeffectgraph/Editor/Compiler/VFXCodeGenerator.cs:369 
  at UnityEditor.VFX.VFXCodeGenerator.Build (UnityEditor.VFX.VFXContext context, UnityEditor.VFX.VFXCompilationMode compilationMode, UnityEditor.VFX.VFXContextCompiledData contextData, System.Collections.Generic.HashSet`1[T] dependencies) [0x0001e] in /__w/1/s/UnityGraphics/com.unity.visualeffectgraph/Editor/Compiler/VFXCodeGenerator.cs:191 
  at UnityEditor.VFX.VFXGraphCompiledData.GenerateShaders (System.Collections.Generic.List`1[T] outGeneratedCodeData, UnityEditor.VFX.VFXExpressionGraph graph, System.Collections.Generic.IEnumerable`1[T] contexts, System.Collections.Generic.Dictionary`2[TKey,TValue] contextToCompiledData, UnityEditor.VFX.VFXCompilationMode compilationMode, System.Collections.Generic.HashSet`1[T] dependencies) [0x0005e] in /__w/1/s/UnityGraphics/com.unity.visualeffectgraph/Editor/Compiler/VFXGraphCompiledData.cs:675 
  at UnityEditor.VFX.VFXGraphCompiledData.Compile (UnityEditor.VFX.VFXCompilationMode compilationMode, System.Boolean forceShaderValidation) [0x005d8] in /__w/1/s/UnityGraphics/com.unity.visualeffectgraph/Editor/Compiler/VFXGraphCompiledData.cs:1003 :   at System.IO.FileStream..ctor (System.String path, System.IO.FileMode mode, System.IO.FileAccess access, System.IO.FileShare share, System.Int32 bufferSize, System.Boolean anonymous, System.IO.FileOptions options) [0x00164] in <fb001e01371b4adca20013e0ac763896>:0 
```

This code in the `visualeffectgraph` package uses a method to format file paths for reading from disk. The format method normalizes the paths to lowercase, except when `UNITY_STANDALONE_LINUX` is defined. This is the correct behavior for a standalone Linux build because Linux filesystems are case-sensitive. However this check doesn't cover the case of running in a Linux _editor_. In that case, paths should also remain case-sensitive.