### PR TITLE
Specular Fixes

### DIFF
--- a/com.unity.render-pipelines.universal/Shaders/ComplexLit.shader
+++ b/com.unity.render-pipelines.universal/Shaders/ComplexLit.shader
@@ -110,6 +110,11 @@ Shader "Universal Render Pipeline/Complex Lit"
             #pragma shader_feature_local_fragment _SPECULAR_SETUP
             #pragma shader_feature_local _RECEIVE_SHADOWS_OFF
 
+            // (ASG)
+            #pragma multi_compile _ _COLOR_TRANSFORM_IN_FORWARD
+            // If HDR_GRADING is on, then the tonemap algorithm is encoded in the HDR LUT
+            #pragma multi_compile _ _HDR_GRADING _TONEMAP_ACES _TONEMAP_NEUTRAL
+
             // -------------------------------------
             // Universal Pipeline keywords
             #pragma multi_compile _ _MAIN_LIGHT_SHADOWS


### PR DESCRIPTION
- Fixes environmental glossy lighting (from reflection probes) on all objects.
- Removes "ambient environment lighting" from all objects, which is enabled normally when environment lighting is disabled. This adds light based on the skybox, which looks terrible for all objects indoors.
- Patch ComplexLit.shader to allow forward pass post processing.