### PR TITLE
Enable color transform in forward pass for ParticlesLit shader

### DIFF
--- a/com.unity.render-pipelines.universal/Shaders/Particles/ParticlesLit.shader
+++ b/com.unity.render-pipelines.universal/Shaders/Particles/ParticlesLit.shader
@@ -98,6 +98,11 @@ Shader "Universal Render Pipeline/Particles/Lit"
             #pragma shader_feature_local _FADING_ON
             #pragma shader_feature_local _DISTORTION_ON
 
+            // (ASG)
+            #pragma multi_compile _ _COLOR_TRANSFORM_IN_FORWARD
+            // If HDR_GRADING is on, then the tonemap algorithm is encoded in the HDR LUT
+            #pragma multi_compile _ _HDR_GRADING _TONEMAP_ACES _TONEMAP_NEUTRAL
+
             // -------------------------------------
             // Universal Pipeline keywords
             #pragma multi_compile _ _MAIN_LIGHT_SHADOWS

--- a/com.unity.render-pipelines.universal/Shaders/Particles/ParticlesLitForwardPass.hlsl
+++ b/com.unity.render-pipelines.universal/Shaders/Particles/ParticlesLitForwardPass.hlsl
@@ -4,6 +4,10 @@
 #include "Packages/com.unity.render-pipelines.universal/ShaderLibrary/Lighting.hlsl"
 #include "Packages/com.unity.render-pipelines.universal/ShaderLibrary/Particles.hlsl"
 
+// (ASG) Include a few post processing functions from a file. But only the functions.
+#define UNIVERSAL_POSTPROCESSING_COMMON_ONLY_INCLUDE_UTILS
+#include "Packages/com.unity.render-pipelines.universal/Shaders/PostProcessing/Common.hlsl"
+
 void InitializeInputData(VaryingsParticle input, half3 normalTS, out InputData output)
 {
     output = (InputData)0;
@@ -118,6 +122,13 @@ half4 ParticlesLitFragment(VaryingsParticle input) : SV_Target
 
     half4 color = UniversalFragmentPBR(inputData, surfaceData);
     color.rgb = MixFog(color.rgb, inputData.fogCoord);
+
+    // (ASG) Add tonemapping and color grading in forward pass.
+    // This uses the same color grading function as the post processing shader.
+#ifdef _COLOR_TRANSFORM_IN_FORWARD
+    color.rgb = ApplyColorGrading(color.rgb, _Lut_Params.w, TEXTURE2D_ARGS(_InternalLut, sampler_LinearClamp), _Lut_Params.xyz, TEXTURE2D_ARGS(_UserLut, sampler_LinearClamp), _UserLut_Params.xyz, _UserLut_Params.w);
+#endif
+
     color.a = OutputAlpha(color.a, _Surface);
 
     return color;

--- a/com.unity.render-pipelines.universal/Shaders/Particles/ParticlesLitInput.hlsl
+++ b/com.unity.render-pipelines.universal/Shaders/Particles/ParticlesLitInput.hlsl
@@ -21,6 +21,18 @@ half _DistortionBlend;
 half _Surface;
 CBUFFER_END
 
+// (ASG) Used when tonemapping and color grading is done in the forward pass.
+#ifdef _COLOR_TRANSFORM_IN_FORWARD
+
+float4 _Lut_Params;
+float4 _UserLut_Params;
+TEXTURE2D(_UserLut);
+TEXTURE2D(_InternalLut);
+SAMPLER(sampler_LinearClamp);
+float _TestParam;
+
+#endif
+
 #include "Packages/com.unity.render-pipelines.universal/ShaderLibrary/Particles.hlsl"
 
 TEXTURE2D(_MetallicGlossMap);   SAMPLER(sampler_MetallicGlossMap);


### PR DESCRIPTION
Noticed that meshes using the Lit shader and the ParticlesLit shader with the same colors rendered as noticeably different colors, then figured out that ParticlesLit wasn't using the color-transform-in-forward-pass step. I copied over the changes from the Lit shader and then the meshes rendered as expected. @Kleptine take a look and let me know if this should be done differently.