### PR TITLE
Add real-time main light toggle

### DIFF
--- a/com.unity.render-pipelines.universal/Editor/ShaderGUI/Shaders/LitShader.cs
+++ b/com.unity.render-pipelines.universal/Editor/ShaderGUI/Shaders/LitShader.cs
@@ -78,11 +78,13 @@ namespace UnityEditor.Rendering.Universal.ShaderGUI
         // material main advanced options
         public override void DrawAdvancedOptions(Material material)
         {
-            if (litProperties.reflections != null && litProperties.highlights != null)
+            // (ASG) added 'realtimeMainLight' property.
+            if (litProperties.reflections != null && litProperties.highlights != null && litProperties.realtimeMainLight != null)
             {
                 EditorGUI.BeginChangeCheck();
                 materialEditor.ShaderProperty(litProperties.highlights, LitGUI.Styles.highlightsText);
                 materialEditor.ShaderProperty(litProperties.reflections, LitGUI.Styles.reflectionsText);
+                materialEditor.ShaderProperty(litProperties.realtimeMainLight, LitGUI.Styles.realtimeMainLightText);
                 if(EditorGUI.EndChangeCheck())
                 {
                     MaterialChanged(material);

--- a/com.unity.render-pipelines.universal/Editor/ShaderGUI/ShadingModels/LitGUI.cs
+++ b/com.unity.render-pipelines.universal/Editor/ShaderGUI/ShadingModels/LitGUI.cs
@@ -44,6 +44,11 @@ namespace UnityEditor.Rendering.Universal.ShaderGUI
                 new GUIContent("Environment Reflections",
                     "When enabled, the Material samples reflections from the nearest Reflection Probes or Lighting Probe.");
 
+            // (ASG)
+            public static GUIContent realtimeMainLightText =
+                new GUIContent("Real-time Main Light",
+                    "When enabled, real-time main light will be blended with baked lighting.");
+
             public static GUIContent heightMapText = new GUIContent("Height Map",
                 "Specifies the Height Map (G) for this Material.");
 
@@ -89,6 +94,8 @@ namespace UnityEditor.Rendering.Universal.ShaderGUI
             // Advanced Props
             public MaterialProperty highlights;
             public MaterialProperty reflections;
+            // (ASG)
+            public MaterialProperty realtimeMainLight;
 
             public MaterialProperty clearCoat;  // Enable/Disable dummy property
             public MaterialProperty clearCoatMap;
@@ -115,6 +122,8 @@ namespace UnityEditor.Rendering.Universal.ShaderGUI
                 // Advanced Props
                 highlights = BaseShaderGUI.FindProperty("_SpecularHighlights", properties, false);
                 reflections = BaseShaderGUI.FindProperty("_EnvironmentReflections", properties, false);
+                // (ASG)
+                realtimeMainLight = BaseShaderGUI.FindProperty("_RealtimeMainLight", properties, false);
 
                 clearCoat           = BaseShaderGUI.FindProperty("_ClearCoat", properties, false);
                 clearCoatMap        = BaseShaderGUI.FindProperty("_ClearCoatMap", properties, false);
@@ -294,6 +303,10 @@ namespace UnityEditor.Rendering.Universal.ShaderGUI
             if (material.HasProperty("_EnvironmentReflections"))
                 CoreUtils.SetKeyword(material, "_ENVIRONMENTREFLECTIONS_OFF",
                     material.GetFloat("_EnvironmentReflections") == 0.0f);
+            // (ASG)
+            if (material.HasProperty("_RealtimeMainLight"))
+                CoreUtils.SetKeyword(material, "_REALTIME_MAIN_LIGHT_ON",
+                    material.GetFloat("_RealtimeMainLight") != 0.0f);
             if (material.HasProperty("_OcclusionMap"))
                 CoreUtils.SetKeyword(material, "_OCCLUSIONMAP", material.GetTexture("_OcclusionMap"));
 

--- a/com.unity.render-pipelines.universal/ShaderLibrary/Lighting.hlsl
+++ b/com.unity.render-pipelines.universal/ShaderLibrary/Lighting.hlsl
@@ -867,7 +867,9 @@ half4 UniversalFragmentPBR(InputData inputData, SurfaceData surfaceData)
     half4 shadowMask = half4(1, 1, 1, 1);
 #endif
 
-    // Light mainLight = GetMainLight(inputData.shadowCoord, inputData.positionWS, shadowMask);
+    #if defined(_REALTIME_MAIN_LIGHT_ON) // (ASG)
+        Light mainLight = GetMainLight(inputData.shadowCoord, inputData.positionWS, shadowMask);
+    #endif
 
     #if defined(_SCREEN_SPACE_OCCLUSION)
         AmbientOcclusionFactor aoFactor = GetScreenSpaceAmbientOcclusion(inputData.normalizedScreenSpaceUV);
@@ -875,17 +877,23 @@ half4 UniversalFragmentPBR(InputData inputData, SurfaceData surfaceData)
         surfaceData.occlusion = min(surfaceData.occlusion, aoFactor.indirectAmbientOcclusion);
     #endif
 
-    // MixRealtimeAndBakedGI(mainLight, inputData.normalWS, inputData.bakedGI);
+    #if defined(_REALTIME_MAIN_LIGHT_ON) // (ASG)
+        MixRealtimeAndBakedGI(mainLight, inputData.normalWS, inputData.bakedGI);
+    #endif
+
     half3 giDirectionWS = SafeNormalize(inputData.bakedGI_directionWS);
     half3 gi = GlobalIllumination(brdfData, brdfLightmaps, brdfDataClearCoat, surfaceData.clearCoatMask,
                                      inputData.bakedGI, giDirectionWS, surfaceData.occlusion,
                                      inputData.normalWS, inputData.viewDirectionWS);
     half3 color = half3(0,0,0);
     color += gi;
-    // color += LightingPhysicallyBased(brdfData, brdfDataClearCoat,
-    //                                  mainLight,
-    //                                  inputData.normalWS, inputData.viewDirectionWS,
-    //                                  surfaceData.clearCoatMask, specularHighlightsOff);
+
+    #if defined(_REALTIME_MAIN_LIGHT_ON) // (ASG)
+        color += LightingPhysicallyBased(brdfData, brdfDataClearCoat,
+                                         mainLight,
+                                         inputData.normalWS, inputData.viewDirectionWS,
+                                         surfaceData.clearCoatMask, specularHighlightsOff);
+    #endif
 
 #ifdef _ADDITIONAL_LIGHTS
     uint pixelLightCount = GetAdditionalLightsCount();

--- a/com.unity.render-pipelines.universal/Shaders/Lit.shader
+++ b/com.unity.render-pipelines.universal/Shaders/Lit.shader
@@ -23,6 +23,9 @@ Shader "Universal Render Pipeline/Lit"
         [ToggleOff] _SpecularHighlights("Specular Highlights", Float) = 1.0
         [ToggleOff] _EnvironmentReflections("Environment Reflections", Float) = 1.0
 
+        // (ASG)
+        [Toggle] _RealtimeMainLight("Real-time Main Light", Float) = 0
+
         _BumpScale("Scale", Float) = 1.0
         _BumpMap("Normal Map", 2D) = "bump" {}
 
@@ -115,6 +118,7 @@ Shader "Universal Render Pipeline/Lit"
             #pragma multi_compile _ _COLOR_TRANSFORM_IN_FORWARD
             // If HDR_GRADING is on, then the tonemap algorithm is encoded in the HDR LUT
             #pragma multi_compile _ _HDR_GRADING _TONEMAP_ACES _TONEMAP_NEUTRAL
+            #pragma shader_feature_local_fragment _REALTIME_MAIN_LIGHT_ON
 
             // -------------------------------------
             // Universal Pipeline keywords
@@ -404,6 +408,7 @@ Shader "Universal Render Pipeline/Lit"
             #pragma multi_compile _ _COLOR_TRANSFORM_IN_FORWARD
             // If HDR_GRADING is on, then the tonemap algorithm is encoded in the HDR LUT
             #pragma multi_compile _ _HDR_GRADING _TONEMAP_ACES _TONEMAP_NEUTRAL
+            #pragma shader_feature_local_fragment _REALTIME_MAIN_LIGHT_ON
 
             // -------------------------------------
             // Universal Pipeline keywords


### PR DESCRIPTION
Adds a toggle in the URP 'Lit' shader to enable real-time main light per material.

![Screenshot 2021-11-09 033704](https://user-images.githubusercontent.com/3371850/140890879-7d83ac92-fab8-47a8-8515-3f9634b42e51.png)
