### PR TITLE
Apply FadeToBlack in URP Particle and Sprite shaders

### DIFF
--- a/com.unity.render-pipelines.universal/Shaders/2D/Sprite-Lit-Default.shader
+++ b/com.unity.render-pipelines.universal/Shaders/2D/Sprite-Lit-Default.shader
@@ -65,6 +65,9 @@ Shader "Universal Render Pipeline/2D/Sprite-Lit-Default"
             half4 _MainTex_ST;
             half4 _NormalMap_ST;
 
+            // (ASG) Support fading to black.
+            float _FadeToBlack;
+
             #if USE_SHAPE_LIGHT_TYPE_0
             SHAPE_LIGHT(0)
             #endif
@@ -101,8 +104,12 @@ Shader "Universal Render Pipeline/2D/Sprite-Lit-Default"
             {
                 half4 main = i.color * SAMPLE_TEXTURE2D(_MainTex, sampler_MainTex, i.uv);
                 half4 mask = SAMPLE_TEXTURE2D(_MaskTex, sampler_MaskTex, i.uv);
+                half4 color = CombinedShapeLightShared(main, mask, i.lightingUV);
 
-                return CombinedShapeLightShared(main, mask, i.lightingUV);
+                // (ASG) Apply fade to black.
+                color.rgb *= _FadeToBlack; // Fading happens in linear color to fade bright spots last
+
+                return color;
             }
             ENDHLSL
         }
@@ -194,6 +201,9 @@ Shader "Universal Render Pipeline/2D/Sprite-Lit-Default"
             SAMPLER(sampler_MainTex);
             float4 _MainTex_ST;
 
+            // (ASG) Support fading to black.
+            float _FadeToBlack;
+
             Varyings UnlitVertex(Attributes attributes)
             {
                 Varyings o = (Varyings)0;
@@ -210,6 +220,10 @@ Shader "Universal Render Pipeline/2D/Sprite-Lit-Default"
             float4 UnlitFragment(Varyings i) : SV_Target
             {
                 float4 mainTex = i.color * SAMPLE_TEXTURE2D(_MainTex, sampler_MainTex, i.uv);
+
+                // (ASG) Apply fade to black.
+                mainTex.rgb *= _FadeToBlack; // Fading happens in linear color to fade bright spots last
+
                 return mainTex;
             }
             ENDHLSL

--- a/com.unity.render-pipelines.universal/Shaders/Particles/ParticlesLitForwardPass.hlsl
+++ b/com.unity.render-pipelines.universal/Shaders/Particles/ParticlesLitForwardPass.hlsl
@@ -123,6 +123,9 @@ half4 ParticlesLitFragment(VaryingsParticle input) : SV_Target
     half4 color = UniversalFragmentPBR(inputData, surfaceData);
     color.rgb = MixFog(color.rgb, inputData.fogCoord);
 
+    // (ASG) Apply global fade to black.
+    color.rgb *= _FadeToBlack; // Fading happens in linear color to fade bright spots last
+
     // (ASG) Add tonemapping and color grading in forward pass.
     // This uses the same color grading function as the post processing shader.
 #ifdef _COLOR_TRANSFORM_IN_FORWARD

--- a/com.unity.render-pipelines.universal/Shaders/Particles/ParticlesLitInput.hlsl
+++ b/com.unity.render-pipelines.universal/Shaders/Particles/ParticlesLitInput.hlsl
@@ -29,9 +29,11 @@ float4 _UserLut_Params;
 TEXTURE2D(_UserLut);
 TEXTURE2D(_InternalLut);
 SAMPLER(sampler_LinearClamp);
-float _TestParam;
 
 #endif
+
+// (ASG) Support fading to black.
+float _FadeToBlack;
 
 #include "Packages/com.unity.render-pipelines.universal/ShaderLibrary/Particles.hlsl"
 

--- a/com.unity.render-pipelines.universal/Shaders/Particles/ParticlesUnlitForwardPass.hlsl
+++ b/com.unity.render-pipelines.universal/Shaders/Particles/ParticlesUnlitForwardPass.hlsl
@@ -112,6 +112,15 @@ half4 fragParticleUnlit(VaryingsParticle input) : SV_Target
     result = MixFog(result, fogFactor);
     albedo.a = OutputAlpha(albedo.a, _Surface);
 
+    // (ASG) Apply global fade to black.
+    result.rgb *= _FadeToBlack; // Fading happens in linear color to fade bright spots last
+
+    // (ASG) Add tonemapping and color grading in forward pass.
+    // This uses the same color grading function as the post processing shader.
+#ifdef _COLOR_TRANSFORM_IN_FORWARD
+    color.rgb = ApplyColorGrading(result.rgb, _Lut_Params.w, TEXTURE2D_ARGS(_InternalLut, sampler_LinearClamp), _Lut_Params.xyz, TEXTURE2D_ARGS(_UserLut, sampler_LinearClamp), _UserLut_Params.xyz, _UserLut_Params.w);
+#endif
+
     return half4(result, albedo.a);
 }
 

--- a/com.unity.render-pipelines.universal/Shaders/Particles/ParticlesUnlitInput.hlsl
+++ b/com.unity.render-pipelines.universal/Shaders/Particles/ParticlesUnlitInput.hlsl
@@ -18,6 +18,20 @@ CBUFFER_START(UnityPerMaterial)
     half _Surface;
 CBUFFER_END
 
+// (ASG) Used when tonemapping and color grading is done in the forward pass.
+#ifdef _COLOR_TRANSFORM_IN_FORWARD
+
+float4 _Lut_Params;
+float4 _UserLut_Params;
+TEXTURE2D(_UserLut);
+TEXTURE2D(_InternalLut);
+SAMPLER(sampler_LinearClamp);
+
+#endif
+
+// (ASG) Support fading to black.
+float _FadeToBlack;
+
 #include "Packages/com.unity.render-pipelines.universal/ShaderLibrary/Particles.hlsl"
 
 #define SOFT_PARTICLE_NEAR_FADE _SoftParticleFadeParams.x


### PR DESCRIPTION
Fixes visual discrepancies when particles and sprites are in view during a fade to black.