### PR TITLE
Use alpha-to-coverage for alpha-cutout shaders

### DIFF
--- a/com.unity.render-pipelines.universal/ShaderLibrary/ShaderVariablesFunctions.hlsl
+++ b/com.unity.render-pipelines.universal/ShaderLibrary/ShaderVariablesFunctions.hlsl
@@ -139,7 +139,12 @@ void AlphaDiscard(real alpha, real cutoff, real offset = 0.0h)
 
 half OutputAlpha(half outputAlpha, half surfaceType = 0.0)
 {
-    return surfaceType == 1 ? outputAlpha : 1.0;
+    // (ASG) Added first branch for alpha-to-coverage.
+    #ifdef _ALPHATEST_ON
+        return outputAlpha;
+    #else
+        return surfaceType == 1 ? outputAlpha : 1.0;
+    #endif
 }
 
 // A word on normalization of normals:

--- a/com.unity.render-pipelines.universal/ShaderLibrary/SurfaceInput.hlsl
+++ b/com.unity.render-pipelines.universal/ShaderLibrary/SurfaceInput.hlsl
@@ -21,9 +21,9 @@ half Alpha(half albedoAlpha, half4 color, half cutoff)
     half alpha = color.a;
 #endif
 
-#if defined(_ALPHATEST_ON)
-    clip(alpha - cutoff);
-#endif
+// #if defined(_ALPHATEST_ON)
+//     clip(alpha - cutoff);
+// #endif
 
     return alpha;
 }

--- a/com.unity.render-pipelines.universal/ShaderLibrary/SurfaceInput.hlsl
+++ b/com.unity.render-pipelines.universal/ShaderLibrary/SurfaceInput.hlsl
@@ -21,9 +21,11 @@ half Alpha(half albedoAlpha, half4 color, half cutoff)
     half alpha = color.a;
 #endif
 
-// #if defined(_ALPHATEST_ON)
-//     clip(alpha - cutoff);
-// #endif
+#if defined(_ALPHATEST_ON)
+    // (ASG) Sharpen alpha boundary using technique from:
+    // https://bgolus.medium.com/anti-aliased-alpha-test-the-esoteric-alpha-to-coverage-8b177335ae4f
+    alpha = (alpha - cutoff) / max(fwidth(alpha), 0.0001) + 0.5;
+#endif
 
     return alpha;
 }

--- a/com.unity.render-pipelines.universal/Shaders/Lit.shader
+++ b/com.unity.render-pipelines.universal/Shaders/Lit.shader
@@ -90,6 +90,9 @@ Shader "Universal Render Pipeline/Lit"
             Name "ForwardLit"
             Tags{"LightMode" = "UniversalForward"}
 
+            // (ASG) Enable AlphaToMask when _AlphaClip (set by material) is on.
+            AlphaToMask[_AlphaClip]
+
             Blend[_SrcBlend][_DstBlend]
             ZWrite[_ZWrite]
             Cull[_Cull]
@@ -374,6 +377,9 @@ Shader "Universal Render Pipeline/Lit"
             // no LightMode tag are also rendered by Universal Render Pipeline
             Name "ForwardLit"
             Tags{"LightMode" = "UniversalForward"}
+
+            // (ASG) Enable AlphaToMask when _AlphaClip (set by material) is on.
+            AlphaToMask[_AlphaClip]
 
             Blend[_SrcBlend][_DstBlend]
             ZWrite[_ZWrite]

--- a/com.unity.render-pipelines.universal/Shaders/LitForwardPass.hlsl
+++ b/com.unity.render-pipelines.universal/Shaders/LitForwardPass.hlsl
@@ -209,10 +209,10 @@ half4 LitPassFragment(Varyings input) : SV_Target
 
     // Return linear color. Conversion to sRGB happens automatically through the sRGB target texture format.
     // If the target does not have sRGB format, sRGB conversion happens during the final blit pass, or post process.
-    
+
     // (ASG) Note: sRGB conversion is better to be done automatically hardware, so that filtering / msaa
     // averaging is done properly in linear space, rather than in sRGB space.
-    
+
     return color;
 }
 


### PR DESCRIPTION
This basically follows the approach here: https://bgolus.medium.com/anti-aliased-alpha-test-the-esoteric-alpha-to-coverage-8b177335ae4f

All Materials using the Lit shader with an "alpha clip" configuration will now use `AlphaToMask` (Unity's name for alpha-to-coverage) in their forward renderer pass.

Worth noting that I did _not_ apply this to other passes in the Lit shader, such as the `DepthOnly` and `ShadowCaster` passes, out of caution. I tested light baking with this setup and didn't observe any obvious problems, but if we notice something later then the solution might be to add `AlphaToMask` in these passes too.