### PR TITLE
Remove UserLUT properties from shaders

### DIFF
--- a/com.unity.render-pipelines.universal/Editor/ShaderGraph/Includes/PBRForwardPass.hlsl
+++ b/com.unity.render-pipelines.universal/Editor/ShaderGraph/Includes/PBRForwardPass.hlsl
@@ -6,8 +6,6 @@
 #ifdef _COLOR_TRANSFORM_IN_FORWARD
 
 float4 _Lut_Params;
-float4 _UserLut_Params;
-TEXTURE2D(_UserLut);
 TEXTURE2D(_InternalLut);
 SAMPLER(sampler_LinearClamp);
 
@@ -129,7 +127,7 @@ half4 frag(PackedVaryings packedInput) : SV_TARGET
     // (ASG) Add tonemapping and color grading in forward pass.
     // This uses the same color grading function as the post processing shader.
 #ifdef _COLOR_TRANSFORM_IN_FORWARD
-    color.rgb = ApplyColorGrading(color.rgb, _Lut_Params.w, TEXTURE2D_ARGS(_InternalLut, sampler_LinearClamp), _Lut_Params.xyz, TEXTURE2D_ARGS(_UserLut, sampler_LinearClamp), _UserLut_Params.xyz, _UserLut_Params.w);
+    color.rgb = ApplyColorGrading(color.rgb, _Lut_Params.w, TEXTURE2D_ARGS(_InternalLut, sampler_LinearClamp), _Lut_Params.xyz);
 #endif
 
     return color;

--- a/com.unity.render-pipelines.universal/Shaders/LitForwardPass.hlsl
+++ b/com.unity.render-pipelines.universal/Shaders/LitForwardPass.hlsl
@@ -202,7 +202,7 @@ half4 LitPassFragment(Varyings input) : SV_Target
     // (ASG) Add tonemapping and color grading in forward pass.
     // This uses the same color grading function as the post processing shader.
 #ifdef _COLOR_TRANSFORM_IN_FORWARD
-    color.rgb = ApplyColorGrading(color.rgb, _Lut_Params.w, TEXTURE2D_ARGS(_InternalLut, sampler_LinearClamp), _Lut_Params.xyz, TEXTURE2D_ARGS(_UserLut, sampler_LinearClamp), _UserLut_Params.xyz, _UserLut_Params.w);
+    color.rgb = ApplyColorGrading(color.rgb, _Lut_Params.w, TEXTURE2D_ARGS(_InternalLut, sampler_LinearClamp), _Lut_Params.xyz);
 #endif
 
     color.a = OutputAlpha(color.a, _Surface);

--- a/com.unity.render-pipelines.universal/Shaders/LitInput.hlsl
+++ b/com.unity.render-pipelines.universal/Shaders/LitInput.hlsl
@@ -34,8 +34,6 @@ CBUFFER_END
 #ifdef _COLOR_TRANSFORM_IN_FORWARD
 
 float4 _Lut_Params;
-float4 _UserLut_Params;
-TEXTURE2D(_UserLut);
 TEXTURE2D(_InternalLut);
 SAMPLER(sampler_LinearClamp);
 float _TestParam;

--- a/com.unity.render-pipelines.universal/Shaders/PostProcessing/UberPost.shader
+++ b/com.unity.render-pipelines.universal/Shaders/PostProcessing/UberPost.shader
@@ -2,7 +2,7 @@ Shader "Hidden/Universal Render Pipeline/UberPost"
 {
     HLSLINCLUDE
         #pragma exclude_renderers gles
-	
+
         // (ASG)
         #pragma multi_compile _ _COLOR_TRANSFORM_IN_FORWARD
         #pragma multi_compile_local_fragment _ _DISTORTION
@@ -32,7 +32,6 @@ Shader "Hidden/Universal Render Pipeline/UberPost"
         TEXTURE2D(_LensDirt_Texture);
         TEXTURE2D(_Grain_Texture);
         TEXTURE2D(_InternalLut);
-        TEXTURE2D(_UserLut);
         TEXTURE2D(_BlueNoise_Texture);
 
         float4 _Lut_Params;
@@ -75,8 +74,6 @@ Shader "Hidden/Universal Render Pipeline/UberPost"
 
         #define LutParams               _Lut_Params.xyz
         #define PostExposure            _Lut_Params.w
-        #define UserLutParams           _UserLut_Params.xyz
-        #define UserLutContribution     _UserLut_Params.w
 
         #define GrainIntensity          _Grain_Params.x
         #define GrainResponse           _Grain_Params.y
@@ -198,7 +195,7 @@ Shader "Hidden/Universal Render Pipeline/UberPost"
             #if !_COLOR_TRANSFORM_IN_FORWARD
             {
                 // (ASG) Color grading does not have a specific keyword toggle. It's always on, unless it's been moved to the forward pass.
-                color = ApplyColorGrading(color, PostExposure, TEXTURE2D_ARGS(_InternalLut, sampler_LinearClamp), LutParams, TEXTURE2D_ARGS(_UserLut, sampler_LinearClamp), UserLutParams, UserLutContribution);
+                color = ApplyColorGrading(color, PostExposure, TEXTURE2D_ARGS(_InternalLut, sampler_LinearClamp), LutParams);
             }
             #endif
 


### PR DESCRIPTION
UserLUT properties are unused, so remove them from color grading functions. 