### PR TITLE
Add toggle for using occlusion values from metallic map sample

### DIFF
--- a/com.unity.render-pipelines.universal/Shaders/Lit.shader
+++ b/com.unity.render-pipelines.universal/Shaders/Lit.shader
@@ -25,6 +25,7 @@ Shader "Universal Render Pipeline/Lit"
 
         // (ASG)
         [Toggle] _RealtimeMainLight("Real-time Main Light", Float) = 0
+        [Toggle] _OcclusionMapCombined("Combined Metallic-Occlusion Map", Float) = 0
 
         _BumpScale("Scale", Float) = 1.0
         _BumpMap("Normal Map", 2D) = "bump" {}
@@ -122,6 +123,7 @@ Shader "Universal Render Pipeline/Lit"
             // If HDR_GRADING is on, then the tonemap algorithm is encoded in the HDR LUT
             #pragma multi_compile _ _HDR_GRADING _TONEMAP_ACES _TONEMAP_NEUTRAL
             #pragma shader_feature_local_fragment _REALTIME_MAIN_LIGHT_ON
+            #pragma shader_feature_local_fragment _OCCLUSION_MAP_COMBINED_ON
 
             // -------------------------------------
             // Universal Pipeline keywords
@@ -415,6 +417,7 @@ Shader "Universal Render Pipeline/Lit"
             // If HDR_GRADING is on, then the tonemap algorithm is encoded in the HDR LUT
             #pragma multi_compile _ _HDR_GRADING _TONEMAP_ACES _TONEMAP_NEUTRAL
             #pragma shader_feature_local_fragment _REALTIME_MAIN_LIGHT_ON
+            #pragma shader_feature_local_fragment _OCCLUSION_MAP_COMBINED_ON
 
             // -------------------------------------
             // Universal Pipeline keywords

--- a/com.unity.render-pipelines.universal/Shaders/LitInput.hlsl
+++ b/com.unity.render-pipelines.universal/Shaders/LitInput.hlsl
@@ -229,7 +229,11 @@ inline void InitializeStandardLitSurfaceData(float2 uv, out SurfaceData outSurfa
 
     outSurfaceData.smoothness = specGloss.a;
     outSurfaceData.normalTS = SampleNormal(uv, TEXTURE2D_ARGS(_BumpMap, sampler_BumpMap), _BumpScale);
+#if defined(_OCCLUSION_MAP_COMBINED_ON) // (ASG) Added alternate implementation of SampleOcclusion().
+    outSurfaceData.occlusion = LerpWhiteTo(specGloss.g, _OcclusionStrength);
+#else
     outSurfaceData.occlusion = SampleOcclusion(uv);
+#endif
     outSurfaceData.emission = SampleEmission(uv, _EmissionColor.rgb, TEXTURE2D_ARGS(_EmissionMap, sampler_EmissionMap));
 
 #if defined(_CLEARCOAT) || defined(_CLEARCOATMAP)


### PR DESCRIPTION
Allows us to save a redundant texture bind and sample in almost all materials using the Lit shader (or variants of it).
