### PR TITLE
Some vertex shader optimizations

### DIFF
--- a/com.unity.render-pipelines.core/ShaderLibrary/SpaceTransforms.hlsl
+++ b/com.unity.render-pipelines.core/ShaderLibrary/SpaceTransforms.hlsl
@@ -54,7 +54,9 @@ real GetOddNegativeScale()
     // FIXME: We should be able to just return unity_WorldTransformParams.w, but it is not
     // properly set at the moment, when doing ray-tracing; once this has been fixed in cpp,
     // we can revert back to the former implementation.
-    return unity_WorldTransformParams.w >= 0.0 ? 1.0 : -1.0;
+    // (ASG) We don't use ray-tracing!
+    //return unity_WorldTransformParams.w >= 0.0 ? 1.0 : -1.0;
+    return unity_WorldTransformParams.w;
 }
 
 float3 TransformObjectToWorld(float3 positionOS)

--- a/com.unity.render-pipelines.universal/Shaders/LitForwardPass.hlsl
+++ b/com.unity.render-pipelines.universal/Shaders/LitForwardPass.hlsl
@@ -138,7 +138,9 @@ Varyings LitPassVertex(Attributes input)
     // also required for per-vertex lighting and SH evaluation
     VertexNormalInputs normalInput = GetVertexNormalInputs(input.normalOS, input.tangentOS);
 
-    half3 viewDirWS = GetWorldSpaceViewDir(vertexInput.positionWS);
+    // (ASG) Assume perspective projection to prevent branching.
+    //half3 viewDirWS = GetWorldSpaceViewDir(vertexInput.positionWS);
+    half3 viewDirWS = GetCurrentViewPosition() - vertexInput.positionWS;
     half3 vertexLight = VertexLighting(vertexInput.positionWS, normalInput.normalWS);
     half fogFactor = ComputeFogFactor(vertexInput.positionCS.z);
 


### PR DESCRIPTION
Relatively minor vertex shader optimizations.

Other changes that I tried, but made no measurable improvement:
- Defining `UNITY_ASSUME_UNIFORM_SCALING` to simplify some normal vector calculations
- Removing the re-normalize step on normal and tangent vectors
- Removing calculations for fields that end up unused (turns out these get optimized out)

I've omitted those changes to avoid any potential side-effects from them. 
